### PR TITLE
zooming is now a thing

### DIFF
--- a/src/lib/d3-components/Canvas.svelte
+++ b/src/lib/d3-components/Canvas.svelte
@@ -11,6 +11,7 @@
   export let showFormulasDefault = false;
   export let width = '100%';
   export let height = 'auto';
+  export let zoom = 1;
 
   // Is the scene inside an iframe?
   export let isIframe = false;
@@ -32,7 +33,7 @@
 >
   {@const totalWidth = $$slots.splitCanvas ? width / 2 : width}
 
-  <D3Canvas width={totalWidth} {height} {gridType}>
+  <D3Canvas {zoom} width={totalWidth} {height} {gridType}>
     <!-- origin label-->
     <Latex2D latex={'O'} offset={new Vector2(-0.15, -0.16)} />
 
@@ -42,7 +43,7 @@
   {#if $$slots.splitCanvas}
     <div class="canvasDivider" />
 
-    <D3Canvas width={totalWidth} {height} {gridType}>
+    <D3Canvas {zoom} width={totalWidth} {height} {gridType}>
       <!-- origin label-->
       <Latex2D latex={'O'} offset={new Vector2(-0.15, -0.16)} />
 

--- a/src/lib/d3-components/D3Canvas.svelte
+++ b/src/lib/d3-components/D3Canvas.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { GridType } from './grids/GridTypes';
-  import { select, zoom, selectAll } from 'd3';
+  import { select, zoom as zoomD3 } from 'd3';
   import { onMount } from 'svelte';
   import Axis from './Axis.svelte';
 
@@ -8,6 +8,7 @@
   export let height: number;
   export let tickLength = 30;
   export let gridType: GridType;
+  export let zoom: number = 1;
 
   const id = 'canvas-' + Math.random().toString(36).substr(2, 9);
   let svg: SVGSVGElement;
@@ -17,11 +18,12 @@
 
   function handleZoom(e: any) {
     zoomLevel = e.transform.k;
+
     select(`#${id} g`).attr('transform', e.transform);
   }
 
-  const zoomProtocol = zoom<SVGSVGElement, unknown>()
-    .scaleExtent([1 / 3, 3])
+  const zoomProtocol = zoomD3<SVGSVGElement, unknown>()
+    .scaleExtent([1 / 3 / zoom, 3 / zoom])
     .on('zoom', handleZoom);
 
   function handleResize() {
@@ -37,13 +39,16 @@
 
 <svg {id} bind:this={svg} {width} {height} viewBox="0 0 {width} {height}">
   <g>
-    <Axis {width} {height} {zoomLevel} length={tickLength} {gridType} />
+    <g transform-origin="{width / 2} {height / 2}" transform="scale({zoom})">
+      <Axis {width} {height} {zoomLevel} length={tickLength} {gridType} />
 
-    <g
-      transform="translate({width / 2}, {height / 2}) scale({(2 * vmax) / 30}, {(-1 * (2 * vmax)) /
-        30})"
-    >
-      <slot />
+      <g
+        transform="translate({width / 2}, {height / 2}) scale({(2 * vmax) / 30}, {(-1 *
+          (2 * vmax)) /
+          30})"
+      >
+        <slot />
+      </g>
     </g>
   </g>
 </svg>

--- a/src/lib/d3-components/grids/Grid.svelte
+++ b/src/lib/d3-components/grids/Grid.svelte
@@ -14,8 +14,6 @@
   export let side: 'x' | 'y' = 'x';
   export let type: GridType;
 
-  console.log({ type });
-
   const strokeWidth = 0.25;
 
   $: vmax = Math.max(width, height);

--- a/src/lib/d3-components/stories/Canvas.stories.svelte
+++ b/src/lib/d3-components/stories/Canvas.stories.svelte
@@ -11,7 +11,10 @@
       title: { type: 'string' },
       background: { type: 'string' }
     },
-    parameters: docsForStory('Canvas is a component that allows you to draw 2d components on a canvas', 'The start of each 2d component')
+    parameters: docsForStory(
+      'Canvas is a component that allows you to draw 2d components on a canvas.',
+      'The start of each 2d component'
+    )
   } satisfies Meta<Canvas>;
 </script>
 
@@ -23,17 +26,11 @@
 </script>
 
 <Template let:args>
+  <!-- To see the details of `{...args}` in action, look at the canvas docs properties panel. -->
   <Canvas height="20rem" {...args} />
 </Template>
 
-<!-- Dynamic snippet should be disabled for this story -->
-<Story
-  name="Default"
-  source
-  parameters={docsForStory('your story-specific description here')}
->
-  <Canvas height="20rem" />
-</Story>
+<Story name="Default" source />
 
 <!-- Dynamic snippet should be disabled for this story -->
 <Story name="With title" source args={{ title: 'Hello this is a title' }} />
@@ -43,9 +40,12 @@
 <Story
   name="Split canvas"
   source
-  parameters={docsForStory('Adding a split canvas is trivial, add a `svelte:fragment` with a slot to splitCanvas and populate the second canvas like normal (this can even be a canvas3D). See code for more details.')}
+  parameters={docsForStory(
+    'Adding a split canvas is trivial, add a `svelte:fragment` with a slot to splitCanvas and populate the second canvas like normal (this can even be a canvas3D). See code for more details.'
+  )}
+  let:args
 >
-  <Canvas height="20rem">
+  <Canvas height="20rem" {...args}>
     <Vector direction={new Vector2(1, 2)} length={3} color={PrimeColor.red} />
 
     <svelte:fragment slot="splitCanvas">
@@ -54,3 +54,16 @@
     </svelte:fragment>
   </Canvas>
 </Story>
+
+<Story
+  name="Zoom out"
+  source
+  args={{ zoom: 0.5 }}
+  parameters={docsForStory('This canvas is zoomed out 2x by specifying zoom=0.5')}
+/>
+<Story
+  name="Zoom in"
+  source
+  args={{ zoom: 2.0 }}
+  parameters={docsForStory('This canvas is zoomed in 2x by specifying zoom=2')}
+/>

--- a/src/lib/d3-components/stories/Draggable.stories.svelte
+++ b/src/lib/d3-components/stories/Draggable.stories.svelte
@@ -17,6 +17,7 @@
   import Canvas from '../Canvas.svelte';
   import { PrimeColor } from '$lib/utils/PrimeColors';
   import docsForStory from '$lib/utils/docsForStory';
+  import { Vector2 } from 'three';
 </script>
 
 <Template let:args>
@@ -26,11 +27,31 @@
   </Canvas>
 </Template>
 
-<!-- Dynamic snippet should be disabled for this story -->
-<Story name="With color" source args={{ color: PrimeColor.green }} />
+<Story name="Default" source />
 
-<!-- 
-<Story name="With points defined" source args={{ points: [new Vector2(1,1), new Vector2(-1,-1)] }} />
-<Story name="With origin defined" source args={{ origin: new Vector2(1, 1) }} />
-<Story name="With width defined" source args={{ width: 0.1 }} />
-<Story name="With distance defined" source args={{ distance: 1 }} /> -->
+<Story
+  name="Make sure each draggable has a unique id"
+  parameters={docsForStory(
+    `> ⚠️ What ever you do, do not forget the add the ids
+
+     When draggables do not have a unique id, they will not have the correct (re-)start position.`
+  )}
+  source
+  let:args
+>
+  <Canvas height="20rem" {...args} title="Left is wrong, Right is good">
+    <!-- THESE are WRONG because they do not have ids -->
+    <Draggable {...args} position={new Vector2(1, 2)} color={PrimeColor.green} />
+    <Draggable {...args} position={new Vector2(2, 1)} color={PrimeColor.red} />
+
+    <svelte:fragment slot="splitCanvas">
+      <!-- THESE are correct because they have unique ids -->
+      <Draggable {...args} position={new Vector2(1, 2)} color={PrimeColor.green} id="a" />
+      <Draggable {...args} position={new Vector2(2, 1)} color={PrimeColor.red} id="b" />
+    </svelte:fragment>
+  </Canvas>
+</Story>
+
+<Story name="With color" source args={{ color: PrimeColor.green, id: 'color' }} />
+
+<Story name="With position" source args={{ position: new Vector2(1, 2), id: 'position' }} />


### PR DESCRIPTION
Zooming in 2d canvasses is now a thing. Jippy :).

Just set <Canvas {zoom}> where zoom is between 0-1 if zoomed out. And 1-Inf when zoomed in. 
Changes can be reviewed here:
https://www.chromatic.com/build?appId=64bd84b22e54c77ce9fcbc6b&number=6

Changes can be observed here:
https://zoom-for-2d-canvas--64bd84b22e54c77ce9fcbc6b.chromatic.com/?path=/docs/2d-components-canvas--docs

## Extra changes:
- The canvas story is now reactive
- The draggables story is now better documented