### PR TITLE
Refactor Draggable component to improve pulse effect

### DIFF
--- a/src/lib/d3-components/Draggable.svelte
+++ b/src/lib/d3-components/Draggable.svelte
@@ -62,15 +62,15 @@
 
 <circle
   class="pulse"
-  cx={position.x}
-  cy={position.y}
-  r={INTERACTIVITY_RADIUS.toLocaleString()}
+  r={INTERACTIVITY_RADIUS}
+  opacity="0.5"
   fill={color}
   role="button"
   tabindex="0"
   on:mousedown={activityStore.enable}
+  style="--x:{position.x}; --y:{position.y}"
 />
-<circle cx={position.x} cy={position.y} r={POINT_SIZE.toLocaleString()} fill={color} />
+<circle cx={position.x} cy={position.y} r={POINT_SIZE} fill={color} />
 
 <slot />
 
@@ -80,20 +80,21 @@
 
 <style>
   .pulse {
-    animation: pulse 3s infinite cubic-bezier(0.455, 0.03, 0.515, 0.955);
+    translate: calc(var(--x) * 1px) calc(var(--y) * 1px);
+    animation: pulse 3s infinite;
   }
 
   @keyframes pulse {
     0% {
-      r: 0.5;
+      scale: 1;
       opacity: 0.5;
     }
-    50% {
-      r: 0.3;
+    70% {
+      scale: 0.5;
       opacity: 0.25;
     }
     100% {
-      r: 0.5;
+      scale: 1;
       opacity: 0.5;
     }
   }


### PR DESCRIPTION
Validated that the pulse effect works again for the following browsers

Tested on the following applet: 
https://deploy-preview-212--playful-otter-9e0500.netlify.app/applet/change_of_basis/square_grid

## Mac
- [x] Arc (v1.34.0) (chromium: 122.0.6261.129)
- [x] Safari (v17.2)
- [x] Firefox (v123.0.1)

## Windows
- [x] Edge (v122.0.2365.92)

## Linux (Ubuntu x86_64 emulation)
- [x] Firefox (v??)