### PR TITLE
fix vector equation

### DIFF
--- a/src/routes/applet/lines_and_planes/parametric_vector_equation/+page.svelte
+++ b/src/routes/applet/lines_and_planes/parametric_vector_equation/+page.svelte
@@ -96,9 +96,9 @@
   >
     {#snippet children(endPoint)}
       <Latex2D
-        latex={'k \\cdot \\mathbf{u}'}
+        latex={'r \\cdot \\mathbf{u}'}
         position={endPoint}
-        offset={new Vector2(0.2, 0.3)}
+        offset={new Vector2(0.3, 0.4)}
         color={PrimeColor.darkGreen}
       />
     {/snippet}

--- a/src/routes/applet/lines_and_planes/parametric_vector_equation/+page.svelte
+++ b/src/routes/applet/lines_and_planes/parametric_vector_equation/+page.svelte
@@ -30,13 +30,13 @@
     const f2 = new Formula(
       '\\begin{bmatrix} \\$1 \\\\ \\$2 \\end{bmatrix} &= \\begin{bmatrix} \\$3  \\\\ \\$4 \\end{bmatrix} + \\$5 \\begin{bmatrix} \\$6 \\\\ \\$7 \\end{bmatrix}'
     )
-      .addAutoParam(round(v1.x), PrimeColor.yellow)
-      .addAutoParam(round(v1.y), PrimeColor.yellow)
-      .addAutoParam(round(v0.x), PrimeColor.raspberry)
-      .addAutoParam(round(v0.y), PrimeColor.raspberry)
-      .addAutoParam(controls[0].toFixed(2), PrimeColor.darkGreen)
-      .addAutoParam(round(u.x), PrimeColor.darkGreen)
-      .addAutoParam(round(u.y), PrimeColor.darkGreen);
+      .addAutoParam(round(v1.x, 1), PrimeColor.yellow)
+      .addAutoParam(round(v1.y, 1), PrimeColor.yellow)
+      .addAutoParam(round(v0.x, 1), PrimeColor.raspberry)
+      .addAutoParam(round(v0.y, 1), PrimeColor.raspberry)
+      .addAutoParam(controls[0].toFixed(1), PrimeColor.darkGreen)
+      .addAutoParam(round(u.x, 1), PrimeColor.darkGreen)
+      .addAutoParam(round(u.y, 1), PrimeColor.darkGreen);
 
     return new Formulas(f1, f2).align();
   });
@@ -82,7 +82,7 @@
       <Latex2D
         latex={'\\mathbf{u}'}
         position={endPoint}
-        offset={new Vector2(0.1, 0.2)}
+        offset={new Vector2(0.1, 0.5)}
         color={PrimeColor.darkGreen}
       />
     {/snippet}

--- a/src/routes/applet/lines_and_planes/parametric_vector_equation/+page.svelte
+++ b/src/routes/applet/lines_and_planes/parametric_vector_equation/+page.svelte
@@ -26,7 +26,7 @@
   const dir_L = $derived(v1.clone().sub(v0.clone()));
 
   const formulas = $derived.by(() => {
-    const f1 = new Formula('\\mathbf{v}_1 &= \\mathbf{v}_0 + k \\cdot \\mathbf{u}');
+    const f1 = new Formula('\\mathbf{v}_1 &= \\mathbf{v}_0 + r \\mathbf{u}');
     const f2 = new Formula(
       '\\begin{bmatrix} \\$1 \\\\ \\$2 \\end{bmatrix} &= \\begin{bmatrix} \\$3  \\\\ \\$4 \\end{bmatrix} + \\$5 \\begin{bmatrix} \\$6 \\\\ \\$7 \\end{bmatrix}'
     )
@@ -42,7 +42,7 @@
   });
 </script>
 
-<Canvas2D {draggables} title="A parametric vector of a line">
+<Canvas2D {draggables} {formulas} showFormulasDefault title="A parametric vector of a line">
   <!-- Line L -->
   <InfiniteLine2D origin={v0} direction={dir_L} color={PrimeColor.cyan} />
 

--- a/src/routes/applet/lines_and_planes/vector-equation/+page.svelte
+++ b/src/routes/applet/lines_and_planes/vector-equation/+page.svelte
@@ -1,24 +1,48 @@
 <script lang="ts">
+  import { Controls } from '$lib/controls/Controls';
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';
   import Latex2D from '$lib/d3/Latex2D.svelte';
   import Vector2D from '$lib/d3/Vector2D.svelte';
+  import { Formula, Formulas } from '$lib/utils/Formulas';
+  import { round } from '$lib/utils/MathLib';
   import { PrimeColor } from '$lib/utils/PrimeColors';
   import { Vector2 } from 'three';
 
   const draggables = [
-    new Draggable(new Vector2(-2, 1), PrimeColor.darkGreen, 'u', Draggable.snapToGrid)
+    new Draggable(new Vector2(-2, 1), PrimeColor.darkGreen, 'u', Draggable.snapToGrid),
+    new Draggable(new Vector2(5, 0), PrimeColor.raspberry, 'v0', Draggable.snapToGrid)
   ];
 
-  const v0 = new Vector2(5, 0);
+  const controls = Controls.addSlider(1, -5, 5, 0.5, PrimeColor.darkGreen, 'k', (x) =>
+    round(x).toString()
+  );
+
+  const v0 = $derived(draggables[1].value);
   const u = $derived(draggables[0].value);
 
-  const v1 = $derived(v0.clone().add(u));
+  const v1 = $derived(v0.clone().add(u.clone().multiplyScalar(controls[0])));
   const dir_L = $derived(v1.clone().sub(v0.clone()));
+
+  const formulas = $derived.by(() => {
+    const f1 = new Formula('\\mathbf{v}_1 &= \\mathbf{v}_0 + k \\cdot \\mathbf{u}');
+    const f2 = new Formula(
+      '\\begin{bmatrix} \\$1 \\\\ \\$2 \\end{bmatrix} &= \\begin{bmatrix} \\$3  \\\\ \\$4 \\end{bmatrix} + \\$5 \\begin{bmatrix} \\$6 \\\\ \\$7 \\end{bmatrix}'
+    )
+      .addAutoParam(round(v1.x), PrimeColor.yellow)
+      .addAutoParam(round(v1.y), PrimeColor.yellow)
+      .addAutoParam(round(v0.x), PrimeColor.raspberry)
+      .addAutoParam(round(v0.y), PrimeColor.raspberry)
+      .addAutoParam(controls[0].toFixed(2), PrimeColor.darkGreen)
+      .addAutoParam(round(u.x), PrimeColor.darkGreen)
+      .addAutoParam(round(u.y), PrimeColor.darkGreen);
+
+    return new Formulas(f1, f2).align();
+  });
 </script>
 
-<Canvas2D {draggables}>
+<Canvas2D {controls} {draggables} {formulas}>
   <!-- Line L -->
   <InfiniteLine2D origin={v0} direction={dir_L} color={PrimeColor.cyan} />
 
@@ -53,7 +77,6 @@
   </Vector2D>
 
   <!-- U -->
-  <!-- <Draggable2D snap id="u" bind:position={u} color={PrimeColor.darkGreen} /> -->
   <Vector2D direction={u} length={u.length()} color={PrimeColor.darkGreen}>
     {#snippet children(endPoint)}
       <Latex2D
@@ -65,7 +88,12 @@
     {/snippet}
   </Vector2D>
 
-  <Vector2D origin={v0} direction={u} length={u.length()} color={PrimeColor.darkGreen}>
+  <Vector2D
+    origin={v0}
+    direction={u}
+    length={u.length() * controls[0]}
+    color={PrimeColor.darkGreen}
+  >
     {#snippet children(endPoint)}
       <Latex2D
         latex={'\\mathbf{u}'}

--- a/src/routes/applet/lines_and_planes/vector-equation/+page.svelte
+++ b/src/routes/applet/lines_and_planes/vector-equation/+page.svelte
@@ -98,7 +98,7 @@
       <Latex2D
         latex={'k \\cdot \\mathbf{u}'}
         position={endPoint}
-        offset={new Vector2(0.1, 0.2)}
+        offset={new Vector2(0.2, 0.3)}
         color={PrimeColor.darkGreen}
       />
     {/snippet}

--- a/src/routes/applet/lines_and_planes/vector-equation/+page.svelte
+++ b/src/routes/applet/lines_and_planes/vector-equation/+page.svelte
@@ -96,7 +96,7 @@
   >
     {#snippet children(endPoint)}
       <Latex2D
-        latex={'\\mathbf{u}'}
+        latex={'k \\cdot \\mathbf{u}'}
         position={endPoint}
         offset={new Vector2(0.1, 0.2)}
         color={PrimeColor.darkGreen}

--- a/src/routes/applet/lines_and_planes/vector_equation/+page.svelte
+++ b/src/routes/applet/lines_and_planes/vector_equation/+page.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import { Controls } from '$lib/controls/Controls';
+  import { Draggable } from '$lib/controls/Draggables.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';
+  import Latex2D from '$lib/d3/Latex2D.svelte';
+  import Vector2D from '$lib/d3/Vector2D.svelte';
+  import { Formula, Formulas } from '$lib/utils/Formulas';
+  import { round } from '$lib/utils/MathLib';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+
+  const draggables = [
+    new Draggable(new Vector2(-2, 1), PrimeColor.darkGreen, 'u', Draggable.snapToGrid),
+    new Draggable(new Vector2(5, 0), PrimeColor.raspberry, 'v0', Draggable.snapToGrid)
+  ];
+
+  const controls = Controls.addSlider(1, -5, 5, 0.5, PrimeColor.darkGreen, 'k', (x) =>
+    round(x).toString()
+  );
+
+  const v0 = $derived(draggables[1].value);
+  const u = $derived(draggables[0].value);
+
+  const v1 = $derived(v0.clone().add(u.clone().multiplyScalar(controls[0])));
+  const dir_L = $derived(v1.clone().sub(v0.clone()));
+
+  const formulas = $derived.by(() => {
+    const f1 = new Formula('\\mathbf{v}_1 &= \\mathbf{v}_0 + r \\mathbf{u}');
+    const f2 = new Formula(
+      '\\begin{bmatrix} \\$1 \\\\ \\$2 \\end{bmatrix} &= \\begin{bmatrix} \\$3  \\\\ \\$4 \\end{bmatrix} + \\$5 \\begin{bmatrix} \\$6 \\\\ \\$7 \\end{bmatrix}'
+    )
+      .addAutoParam(round(v1.x), PrimeColor.yellow)
+      .addAutoParam(round(v1.y), PrimeColor.yellow)
+      .addAutoParam(round(v0.x), PrimeColor.raspberry)
+      .addAutoParam(round(v0.y), PrimeColor.raspberry)
+      .addAutoParam(controls[0].toFixed(2), PrimeColor.darkGreen)
+      .addAutoParam(round(u.x), PrimeColor.darkGreen)
+      .addAutoParam(round(u.y), PrimeColor.darkGreen);
+
+    return new Formulas(f1, f2).align();
+  });
+</script>
+
+<Canvas2D {draggables} {formulas} showFormulasDefault title="A parametric vector of a line">
+  <!-- Line L -->
+  <InfiniteLine2D origin={v0} direction={dir_L} color={PrimeColor.cyan} />
+
+  <!-- V0 -->
+  <Vector2D direction={v0} length={v0.length()} color={PrimeColor.raspberry}>
+    {#snippet children(endPoint)}
+      <Latex2D
+        latex={'\\mathbf{v}_0'}
+        position={endPoint}
+        offset={new Vector2(0.1, 0.2)}
+        color={PrimeColor.raspberry}
+      />
+      <Latex2D
+        latex={'\\mathcal{L}_1'}
+        offset={u.clone().multiplyScalar(-0.2).add(new Vector2(-0.2, -0.2))}
+        position={endPoint}
+        color={PrimeColor.blue}
+      />
+    {/snippet}
+  </Vector2D>
+
+  <!-- V1 -->
+  <Vector2D direction={v1} length={v1.length()} color={PrimeColor.yellow}>
+    {#snippet children(endPoint)}
+      <Latex2D
+        latex={'\\mathbf{v}_1'}
+        position={endPoint}
+        offset={new Vector2(-0.3, -0.3)}
+        color={PrimeColor.yellow}
+      />
+    {/snippet}
+  </Vector2D>
+
+  <!-- U -->
+  <Vector2D direction={u} length={u.length()} color={PrimeColor.darkGreen}>
+    {#snippet children(endPoint)}
+      <Latex2D
+        latex={'\\mathbf{u}'}
+        position={endPoint}
+        offset={new Vector2(0.1, 0.2)}
+        color={PrimeColor.darkGreen}
+      />
+    {/snippet}
+  </Vector2D>
+
+  <Vector2D
+    origin={v0}
+    direction={u}
+    length={u.length() * controls[0]}
+    color={PrimeColor.darkGreen}
+  >
+    {#snippet children(endPoint)}
+      <Latex2D
+        latex={'k \\cdot \\mathbf{u}'}
+        position={endPoint}
+        offset={new Vector2(0.2, 0.3)}
+        color={PrimeColor.darkGreen}
+      />
+    {/snippet}
+  </Vector2D>
+</Canvas2D>

--- a/src/routes/applet/lines_and_planes/vector_equation/+page.svelte
+++ b/src/routes/applet/lines_and_planes/vector_equation/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { Controls } from '$lib/controls/Controls';
-  import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';
   import Latex2D from '$lib/d3/Latex2D.svelte';
@@ -10,17 +9,12 @@
   import { PrimeColor } from '$lib/utils/PrimeColors';
   import { Vector2 } from 'three';
 
-  const draggables = [
-    new Draggable(new Vector2(-2, 1), PrimeColor.darkGreen, 'u', Draggable.snapToGrid),
-    new Draggable(new Vector2(5, 0), PrimeColor.raspberry, 'v0', Draggable.snapToGrid)
-  ];
-
   const controls = Controls.addSlider(1, -5, 5, 0.5, PrimeColor.darkGreen, 'k', (x) =>
     round(x).toString()
   );
 
-  const v0 = $derived(draggables[1].value);
-  const u = $derived(draggables[0].value);
+  const u = new Vector2(-2, 1);
+  const v0 = new Vector2(5, 0);
 
   const v1 = $derived(v0.clone().add(u.clone().multiplyScalar(controls[0])));
   const dir_L = $derived(v1.clone().sub(v0.clone()));
@@ -30,19 +24,19 @@
     const f2 = new Formula(
       '\\begin{bmatrix} \\$1 \\\\ \\$2 \\end{bmatrix} &= \\begin{bmatrix} \\$3  \\\\ \\$4 \\end{bmatrix} + \\$5 \\begin{bmatrix} \\$6 \\\\ \\$7 \\end{bmatrix}'
     )
-      .addAutoParam(round(v1.x), PrimeColor.yellow)
-      .addAutoParam(round(v1.y), PrimeColor.yellow)
-      .addAutoParam(round(v0.x), PrimeColor.raspberry)
-      .addAutoParam(round(v0.y), PrimeColor.raspberry)
-      .addAutoParam(controls[0].toFixed(2), PrimeColor.darkGreen)
-      .addAutoParam(round(u.x), PrimeColor.darkGreen)
-      .addAutoParam(round(u.y), PrimeColor.darkGreen);
+      .addAutoParam(round(v1.x, 1), PrimeColor.yellow)
+      .addAutoParam(round(v1.y, 1), PrimeColor.yellow)
+      .addAutoParam(round(v0.x, 1), PrimeColor.raspberry)
+      .addAutoParam(round(v0.y, 1), PrimeColor.raspberry)
+      .addAutoParam(controls[0].toFixed(1), PrimeColor.darkGreen)
+      .addAutoParam(round(u.x, 1), PrimeColor.darkGreen)
+      .addAutoParam(round(u.y, 1), PrimeColor.darkGreen);
 
     return new Formulas(f1, f2).align();
   });
 </script>
 
-<Canvas2D {draggables} {formulas} showFormulasDefault title="A parametric vector of a line">
+<Canvas2D {controls} {formulas} showFormulasDefault title="A parametric vector of a line">
   <!-- Line L -->
   <InfiniteLine2D origin={v0} direction={dir_L} color={PrimeColor.cyan} />
 
@@ -82,7 +76,7 @@
       <Latex2D
         latex={'\\mathbf{u}'}
         position={endPoint}
-        offset={new Vector2(0.1, 0.2)}
+        offset={new Vector2(0.1, 0.5)}
         color={PrimeColor.darkGreen}
       />
     {/snippet}

--- a/src/routes/applet/lines_and_planes/vector_equation/+page.svelte
+++ b/src/routes/applet/lines_and_planes/vector_equation/+page.svelte
@@ -90,9 +90,9 @@
   >
     {#snippet children(endPoint)}
       <Latex2D
-        latex={'k \\cdot \\mathbf{u}'}
+        latex={'r \\cdot \\mathbf{u}'}
         position={endPoint}
-        offset={new Vector2(0.2, 0.3)}
+        offset={new Vector2(0.3, 0.4)}
         color={PrimeColor.darkGreen}
       />
     {/snippet}


### PR DESCRIPTION
now, applet flows better with text

closes #100 

## Before
<img width="1812" alt="image" src="https://github.com/user-attachments/assets/9ac394ce-73e6-4679-b7d5-a29fb4f776dd">

## After

| Vector Equation | Parametric Vector equation |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/8d0bb9a7-4902-478d-b95f-3ee2732172bb) | ![image](https://github.com/user-attachments/assets/2ad16e4a-9002-432d-ae60-950646471dc0) |
| Here you can change `r` with a slider | here you can change `v0` & `u` with draggables |





> [!TIP]
> look at applet: https://deploy-preview-240--playful-otter-9e0500.netlify.app/applet/lines_and_planes/vector_equation
> look at applet: https://deploy-preview-240--playful-otter-9e0500.netlify.app/applet/lines_and_planes/parametric_vector_equation
