### PR TITLE
Injective surjective applets

### DIFF
--- a/src/lib/components/ControllerAndActivityPanel.svelte
+++ b/src/lib/components/ControllerAndActivityPanel.svelte
@@ -66,8 +66,8 @@
   <SideButton
     translate={activityState.isActive
       ? 'left-1/2 -translate-x-1/2 top-5 scale-0'
-      : 'left-1/2 -translate-x-1/2 -top-6 scale-100 motion-safe:hover:scale-105'}
-    class="w-full text-nowrap"
+      : 'left-1/2 -translate-x-1/2  -top-14 sm:-top-6 scale-100 motion-safe:hover:scale-105'}
+    class="w-full h-full text-nowrap"
     tooltip="Start the scene so you can interact"
   >
     <div
@@ -89,21 +89,27 @@
   <!-- LOCK SCENE -->
   <SideButton
     onclick={(e) => onLock(e)}
-    translate={activityState.isActive ? '-left-[4.5rem] opacity-100' : 'left-1 opacity-50'}
+    translate={activityState.isActive
+      ? '-left-12 sm:-left-[4.5rem] opacity-100'
+      : 'left-1 opacity-50'}
     tooltip="Lock the scene so you can scroll again"
+    class="w-10 sm:w-16"
   >
-    <span class="text-xs mr-0.5">Lock</span>
+    <span class="text-xs mr-0.5 hidden sm:block">Lock</span>
     <Lock class="h-4 w-4" />
   </SideButton>
 
   <!-- RESET SCENE -->
   <SideButton
     onclick={onReset}
-    translate={activityState.isActive ? '-right-[4.5rem] opacity-100' : 'right-1 opacity-50'}
+    translate={activityState.isActive
+      ? '-right-12 sm:-right-[4.5rem] opacity-100'
+      : 'right-1 opacity-50'}
     tooltip="Will reset sliders, toggles and scene"
+    class="w-10 sm:w-16"
   >
     <RotateCcw class="h-4 w-4" />
-    <span class="ml-0.5 text-xs">Reset</span>
+    <span class="ml-0.5 text-xs hidden sm:block">Reset</span>
   </SideButton>
 </div>
 

--- a/src/lib/threlte/Polygon3D.svelte
+++ b/src/lib/threlte/Polygon3D.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { T } from '@threlte/core';
+  import {
+    BufferAttribute,
+    BufferGeometry,
+    DoubleSide,
+    Vector3,
+    type BackSide,
+    type FrontSide
+  } from 'three';
+
+  type Polygon3DProps = {
+    points: Vector3[];
+    offset?: Vector3;
+    color?: string;
+    opacity?: number;
+    side?: typeof FrontSide | typeof BackSide | typeof DoubleSide;
+  };
+
+  let {
+    points,
+    offset = new Vector3(),
+    color = PrimeColor.black,
+    opacity = 1,
+    side = DoubleSide
+  }: Polygon3DProps = $props();
+
+  const offsetPoints = $derived(points.map((point) => point.clone().add(offset)));
+
+  const geometry = $derived.by(() => {
+    const geom = new BufferGeometry();
+
+    const vertices = new Float32Array(offsetPoints.map((point) => point.toArray()).flat());
+
+    geom.setAttribute('position', new BufferAttribute(vertices, 3));
+
+    const indices = new Uint16Array(
+      Array.from({ length: offsetPoints.length - 2 }, (_, i) => [0, i + 1, i + 2]).flat()
+    );
+
+    geom.setIndex(new BufferAttribute(indices, 1));
+
+    return geom;
+  });
+</script>
+
+<T.Mesh {geometry}>
+  <T.MeshBasicMaterial {side} {color} transparent={opacity < 1} {opacity} />
+</T.Mesh>

--- a/src/routes/applet/crossproduct/areatriangle/+page.svelte
+++ b/src/routes/applet/crossproduct/areatriangle/+page.svelte
@@ -1,0 +1,98 @@
+<script>
+  import Axis3D from '$lib/threlte/Axis3D.svelte';
+  import Canvas3D from '$lib/threlte/Canvas3D.svelte';
+  import Latex3D from '$lib/threlte/Latex3D.svelte';
+  import Parallelepiped3D from '$lib/threlte/Parallelepiped3D.svelte';
+  import Point3D from '$lib/threlte/Point3D.svelte';
+  import Vector3D from '$lib/threlte/Vector3D.svelte';
+  import { Formula } from '$lib/utils/Formulas';
+  import { MathVector3 } from '$lib/utils/MathVector';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector3 } from 'three';
+
+  let P = new MathVector3(2, 1, 0);
+  let Q = new MathVector3(2, 2, 2);
+  let R = new MathVector3(3, 1, 1);
+
+  const PQ = Q.clone().sub(P);
+  const PR = R.clone().sub(P);
+
+  const formulas = $derived.by(() => {
+    const PQ = Q.clone().sub(P);
+    const PR = R.clone().sub(P);
+    const cp = PQ.cross(PR);
+
+    return [
+      new Formula(
+        `\\vec{PQ} \\times \\vec{QR}= \\begin{bmatrix} ${cp.z} \\\\ ${cp.x} \\\\ ${cp.y} \\end{bmatrix}`
+      )
+    ];
+  });
+</script>
+
+<Canvas3D cameraPosition={new Vector3(-14.7, 5.3, -6.4)} cameraZoom={100} {formulas}>
+  <!-- P -->
+  <Point3D position={P} color={PrimeColor.raspberry} size={0.1} />
+  <Latex3D position={P} offset={new Vector3(-0.3, -0.1, 0)} latex="P" hasBackground />
+
+  <!-- Q -->
+  <Point3D position={Q} color={PrimeColor.raspberry} size={0.1} />
+  <Latex3D position={Q} offset={new Vector3(0.2, -0.3, -0.1)} latex="Q" hasBackground />
+
+  <!-- R -->
+  <Point3D position={R} color={PrimeColor.raspberry} size={0.1} />
+  <Latex3D position={R} offset={new Vector3(-0.3, -0.1, 0)} latex="R" hasBackground />
+
+  <!-- PQ -->
+  <Vector3D
+    origin={P}
+    direction={Q.clone().sub(P)}
+    length={Q.clone().sub(P).length()}
+    color={PrimeColor.blue}
+  />
+
+  <!-- PR -->
+  <Vector3D
+    origin={P}
+    direction={R.clone().sub(P)}
+    length={R.clone().sub(P).length()}
+    color={PrimeColor.blue}
+  />
+
+  <!-- Helper vectors -->
+  <Vector3D
+    origin={Q}
+    direction={R.clone().sub(Q)}
+    length={R.clone().sub(Q).length()}
+    color={PrimeColor.black}
+    isDashed
+    hideHead
+  />
+
+  <!-- P + R -->
+  <Vector3D
+    origin={R}
+    direction={Q.clone().sub(P)}
+    length={Q.clone().sub(P).length()}
+    color={PrimeColor.darkGreen}
+  />
+
+  <!-- Q + R -->
+  <Vector3D
+    origin={Q}
+    direction={R.clone().sub(P)}
+    length={R.clone().sub(P).length()}
+    color={PrimeColor.darkGreen}
+  />
+
+  <!-- Area -->
+  <Parallelepiped3D points={[P, Q, R]} color={PrimeColor.yellow} opacity={0.2} />
+  <Latex3D
+    position={P.clone().add(Q.clone().multiplyScalar(0.5)).add(PR.clone().multiplyScalar(0.5))}
+    offset={new Vector3(0, 0, 0)}
+    latex={`\\text{\\textcolor{${PrimeColor.yellow}}{A}} = 2 \\cdot P \\thinspace Q \\thinspace R`}
+    hasBackground
+  />
+
+  <Axis3D />
+</Canvas3D>

--- a/src/routes/applet/crossproduct/areatriangle/+page.svelte
+++ b/src/routes/applet/crossproduct/areatriangle/+page.svelte
@@ -1,11 +1,13 @@
 <script>
+  import Angle3D from '$lib/threlte/Angle3D.svelte';
   import Axis3D from '$lib/threlte/Axis3D.svelte';
   import Canvas3D from '$lib/threlte/Canvas3D.svelte';
   import Latex3D from '$lib/threlte/Latex3D.svelte';
-  import Parallelepiped3D from '$lib/threlte/Parallelepiped3D.svelte';
   import Point3D from '$lib/threlte/Point3D.svelte';
+  import Polygon3D from '$lib/threlte/Polygon3D.svelte';
   import Vector3D from '$lib/threlte/Vector3D.svelte';
   import { Formula } from '$lib/utils/Formulas';
+  import { round } from '$lib/utils/MathLib';
   import { MathVector3 } from '$lib/utils/MathVector';
   import { PrimeColor } from '$lib/utils/PrimeColors';
   import { Vector3 } from 'three';
@@ -16,32 +18,45 @@
 
   const PQ = Q.clone().sub(P);
   const PR = R.clone().sub(P);
+  const n = PQ.cross(PR);
 
   const formulas = $derived.by(() => {
-    const PQ = Q.clone().sub(P);
-    const PR = R.clone().sub(P);
-    const cp = PQ.cross(PR);
+    const area = 0.5 * n.length();
 
     return [
       new Formula(
-        `\\vec{PQ} \\times \\vec{QR}= \\begin{bmatrix} ${cp.z} \\\\ ${cp.x} \\\\ ${cp.y} \\end{bmatrix}`
+        `\\mathbf{\\$1} = \\overrightarrow{\\mathbf{\\$2}} \\times \\overrightarrow{\\mathbf{\\$3}} = \\$4`
+      )
+        .addAutoParam('n', PrimeColor.orange)
+        .addAutoParam('PQ', PrimeColor.blue)
+        .addAutoParam('PR', PrimeColor.blue)
+        .addAutoParam(
+          `\\begin{bmatrix} ${n.z} \\\\ ${n.x} \\\\ ${n.y} \\end{bmatrix}`,
+          PrimeColor.orange
+        ),
+      new Formula(
+        `\\text{Area}(\\Delta \\mathbf{PQR}) = \\frac{1}{2} ||\\mathbf{n}|| = ${round(area, 1)}`
       )
     ];
   });
 </script>
 
-<Canvas3D cameraPosition={new Vector3(-14.7, 5.3, -6.4)} cameraZoom={100} {formulas}>
+<Canvas3D cameraPosition={new Vector3(-0.74, 4.87, -16.15)} cameraZoom={100} {formulas}>
+  <!-- N -->
+  <Vector3D origin={P} direction={n} length={n.length()} color={PrimeColor.orange} />
+  <Latex3D position={P.clone().add(n)} extend={0.2} latex={'\\mathbf{n}'} hasBackground />
+
   <!-- P -->
   <Point3D position={P} color={PrimeColor.raspberry} size={0.1} />
-  <Latex3D position={P} offset={new Vector3(-0.3, -0.1, 0)} latex="P" hasBackground />
+  <Latex3D position={P} offset={new Vector3(-0.3, -0.1, 0)} latex={'\\mathbf{P}'} hasBackground />
 
   <!-- Q -->
   <Point3D position={Q} color={PrimeColor.raspberry} size={0.1} />
-  <Latex3D position={Q} offset={new Vector3(0.2, -0.3, -0.1)} latex="Q" hasBackground />
+  <Latex3D position={Q} offset={new Vector3(0.2, -0.3, -0.1)} latex={'\\mathbf{Q}'} hasBackground />
 
   <!-- R -->
   <Point3D position={R} color={PrimeColor.raspberry} size={0.1} />
-  <Latex3D position={R} offset={new Vector3(-0.3, -0.1, 0)} latex="R" hasBackground />
+  <Latex3D position={R} offset={new Vector3(-0.3, -0.1, 0)} latex={'\\mathbf{R}'} hasBackground />
 
   <!-- PQ -->
   <Vector3D
@@ -86,11 +101,11 @@
   />
 
   <!-- Area -->
-  <Parallelepiped3D points={[P, Q, R]} color={PrimeColor.yellow} opacity={0.2} />
+  <Polygon3D points={[P, Q, R]} color={PrimeColor.yellow} opacity={0.2} />
   <Latex3D
-    position={P.clone().add(Q.clone().multiplyScalar(0.5)).add(PR.clone().multiplyScalar(0.5))}
+    position={P.clone().add(Q.clone().multiplyScalar(0.5))}
     offset={new Vector3(0, 0, 0)}
-    latex={`\\text{\\textcolor{${PrimeColor.yellow}}{A}} = 2 \\cdot P \\thinspace Q \\thinspace R`}
+    latex={`\\text{\\textcolor{${PrimeColor.yellow}}{A}} = \\text{Area}(\\Delta \\mathbf{PQR})`}
     hasBackground
   />
 

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example/+page.svelte
@@ -65,11 +65,11 @@
   function transform(vector: Vector2) {
     switch (controls[0]) {
       case 'Transformation 1':
-        // Transform 1 - with the matrix [0.8 -2; -0.6 1.5]
-        return new Vector2(0.8 * vector.x - 2 * vector.y, -0.6 * vector.x + 1.5 * vector.y);
-      case 'Transformation 2':
         // Transform 2 - with the matrix [0.5 2; 0.9 -1]
         return new Vector2(0.5 * vector.x + 2 * vector.y, 0.9 * vector.x - vector.y);
+      case 'Transformation 2':
+        // Transform 1 - with the matrix [0.8 -2; -0.6 1.5]
+        return new Vector2(0.8 * vector.x - 2 * vector.y, -0.6 * vector.x + 1.5 * vector.y);
       case 'Transformation 3':
         // Transform 3 - with the matrix [1 3; 2 4]
         return new Vector2(vector.x + 3 * vector.y, 2 * vector.x + 4 * vector.y);
@@ -83,16 +83,16 @@
 
     switch (controls[0]) {
       case 'Transformation 1':
-        const f1 = new Formula(
-          'T(\\mathbf{v})=\\begin{bmatrix}0.8 & -2 \\\\ -0.6 & 1.5 \\end{bmatrix}\\mathbf{v}'
-        );
-        formulas.push(f1);
-        break;
-      case 'Transformation 2':
         const f2 = new Formula(
           'T(\\mathbf{v})=\\begin{bmatrix}0.5 & 2 \\\\ 0.9 & -1 \\end{bmatrix}\\mathbf{v}'
         );
         formulas.push(f2);
+        break;
+      case 'Transformation 2':
+        const f1 = new Formula(
+          'T(\\mathbf{v})=\\begin{bmatrix}0.8 & -2 \\\\ -0.6 & 1.5 \\end{bmatrix}\\mathbf{v}'
+        );
+        formulas.push(f1);
         break;
       case 'Transformation 3':
         const f3 = new Formula(
@@ -141,7 +141,7 @@
     <Latex2D
       position={draggables[0].position}
       offset={new Vector2(-0.5, 0.3)}
-      latex={`\\mathbf{v_1} = T(\\mathbf{v_2})`}
+      latex={`\\mathbf{v_1} = \\mathbf{v_2}`}
       extend={0.3}
     />
   {/if}

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example/+page.svelte
@@ -48,18 +48,20 @@
     switch (controls[0]) {
       case 'Transformation 1':
         const f1 = new Formula(
-          'T(\\mathbf{v})=\\begin{bmatrix}0.8 & -2 \\\\ -0.6 & 1.5 \\end{bmatrix}'
+          'T(\\mathbf{v})=\\begin{bmatrix}0.8 & -2 \\\\ -0.6 & 1.5 \\end{bmatrix}\\mathbf{v}'
         );
         formulas.push(f1);
         break;
       case 'Transformation 2':
         const f2 = new Formula(
-          'T(\\mathbf{v})=\\begin{bmatrix}0.5 & 2 \\\\ 0.9 & -1 \\end{bmatrix}'
+          'T(\\mathbf{v})=\\begin{bmatrix}0.5 & 2 \\\\ 0.9 & -1 \\end{bmatrix}\\mathbf{v}'
         );
         formulas.push(f2);
         break;
       case 'Transformation 3':
-        const f3 = new Formula('T(\\mathbf{v})=\\begin{bmatrix}1 & 3 \\\\ 2 & 4 \\end{bmatrix}');
+        const f3 = new Formula(
+          'T(\\mathbf{v})=\\begin{bmatrix}1 & 3 \\\\ 2 & 4 \\end{bmatrix}\\mathbf{v}'
+        );
         formulas.push(f3);
         break;
     }
@@ -73,7 +75,7 @@
   });
 
   $effect(() => {
-    if (vDistances >= 0.1 && TvDistances < 0.1) {
+    if (vDistances >= 0.5 && TvDistances < 0.1) {
       // Launch confetti
       untrack(() => confettiState.center(1000));
     }

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example/+page.svelte
@@ -94,7 +94,7 @@
       <Latex2D
         position={draggable.position}
         offset={new Vector2(-0.2, 0.3)}
-        latex={`T(\\mathbf{v_${index + 1}})`}
+        latex={`\\mathbf{v_${index + 1}}`}
         color={draggable.color}
         extend={0.3}
       />
@@ -105,7 +105,7 @@
     <Latex2D
       position={draggables[0].position}
       offset={new Vector2(-0.5, 0.3)}
-      latex={`T(\\mathbf{v_1}) = T(\\mathbf{v_2})`}
+      latex={`\\mathbf{v_1} = T(\\mathbf{v_2})`}
       extend={0.3}
     />
   {/if}

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example/+page.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+  import { Controls } from '$lib/controls/Controls';
+  import { Draggable } from '$lib/controls/Draggables.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import Latex2D from '$lib/d3/Latex2D.svelte';
+  import Vector2D from '$lib/d3/Vector2D.svelte';
+  import { confettiState } from '$lib/stores/confetti.svelte';
+  import { Formula } from '$lib/utils/Formulas';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { untrack } from 'svelte';
+  import { Vector2 } from 'three';
+
+  const controls = Controls.addDropdown(
+    'Transformation 1',
+    ['Transformation 1', 'Transformation 2', 'Transformation 3'],
+    PrimeColor.blue
+  );
+
+  const draggables = [
+    new Draggable(new Vector2(-1, 2), PrimeColor.blue),
+    new Draggable(new Vector2(3, 2), PrimeColor.raspberry)
+  ];
+
+  const vDistances = $derived(draggables[0].position.distanceTo(draggables[1].position));
+  const TvDistances = $derived(
+    transform(draggables[0].position).distanceTo(transform(draggables[1].position))
+  );
+
+  function transform(vector: Vector2) {
+    switch (controls[0]) {
+      case 'Transformation 1':
+        // Transform 1 - with the matrix [0.8 -2; -0.6 1.5]
+        return new Vector2(0.8 * vector.x - 2 * vector.y, -0.6 * vector.x + 1.5 * vector.y);
+      case 'Transformation 2':
+        // Transform 2 - with the matrix [0.5 2; 0.9 -1]
+        return new Vector2(0.5 * vector.x + 2 * vector.y, 0.9 * vector.x - vector.y);
+      case 'Transformation 3':
+        // Transform 3 - with the matrix [1 3; 2 4]
+        return new Vector2(vector.x + 3 * vector.y, 2 * vector.x + 4 * vector.y);
+      default:
+        return vector;
+    }
+  }
+
+  const formulas = $derived.by(() => {
+    let formulas = [];
+
+    switch (controls[0]) {
+      case 'Transformation 1':
+        const f1 = new Formula(
+          'T(\\mathbf{v})=\\begin{bmatrix}0.8 & -2 \\\\ -0.6 & 1.5 \\end{bmatrix}'
+        );
+        formulas.push(f1);
+        break;
+      case 'Transformation 2':
+        const f2 = new Formula(
+          'T(\\mathbf{v})=\\begin{bmatrix}0.5 & 2 \\\\ 0.9 & -1 \\end{bmatrix}'
+        );
+        formulas.push(f2);
+        break;
+      case 'Transformation 3':
+        const f3 = new Formula('T(\\mathbf{v})=\\begin{bmatrix}1 & 3 \\\\ 2 & 4 \\end{bmatrix}');
+        formulas.push(f3);
+        break;
+    }
+
+    const f4 = new Formula(
+      `\\mathbf{v_1} ${vDistances < 0.1 ? '=' : '\\neq'} \\mathbf{v_2} \\quad T(\\mathbf{v_1}) ${TvDistances < 0.1 ? '=' : '\\neq'} T(\\mathbf{v_2})`
+    );
+    formulas.push(f4);
+
+    return formulas;
+  });
+
+  $effect(() => {
+    if (vDistances >= 0.1 && TvDistances < 0.1) {
+      // Launch confetti
+      untrack(() => confettiState.center(1000));
+    }
+  });
+</script>
+
+<Canvas2D {draggables} {formulas} {controls} showFormulasDefault>
+  {#each draggables as draggable, index}
+    <Vector2D
+      direction={draggable.position}
+      length={draggable.position.length()}
+      color={draggable.color}
+    />
+
+    {#if vDistances >= 0.1}
+      <Latex2D
+        position={draggable.position}
+        offset={new Vector2(-0.2, 0.3)}
+        latex={`T(\\mathbf{v_${index + 1}})`}
+        color={draggable.color}
+        extend={0.3}
+      />
+    {/if}
+  {/each}
+
+  {#if vDistances < 0.1}
+    <Latex2D
+      position={draggables[0].position}
+      offset={new Vector2(-0.5, 0.3)}
+      latex={`T(\\mathbf{v_1}) = T(\\mathbf{v_2})`}
+      extend={0.3}
+    />
+  {/if}
+
+  {#snippet splitCanvas2DChildren()}
+    {#each draggables as draggable, index}
+      {@const transformed = transform(draggable.position)}
+      <Vector2D direction={transformed} length={transformed.length()} color={draggable.color} />
+
+      {#if TvDistances >= 0.1}
+        <Latex2D
+          position={transformed}
+          offset={new Vector2(-0.2, 0.3)}
+          latex={`T(\\mathbf{v_${index + 1}})`}
+          color={draggable.color}
+          extend={0.3}
+        />
+      {/if}
+    {/each}
+
+    {#if TvDistances < 0.1}
+      <Latex2D
+        position={transform(draggables[0].position)}
+        offset={new Vector2(-0.5, 0.3)}
+        latex={`T(\\mathbf{v_1}) = T(\\mathbf{v_2})`}
+        extend={0.3}
+      />
+    {/if}
+  {/snippet}
+</Canvas2D>

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example/+page.svelte
@@ -37,6 +37,10 @@
       const td2 = transform(d2.position);
 
       if (Math.abs(td1.length() - td2.length()) < 1) {
+        if (controls[0] == 'Transformation 2' && d1.position.distanceTo(d2.position) > 0.5) {
+          confettiState.center(1000);
+        }
+
         return v.clone().multiplyScalar(td2.length() / td1.length());
       } else {
         return v;
@@ -48,6 +52,10 @@
       const td2 = transform(d2.position);
 
       if (Math.abs(td1.length() - td2.length()) < 1) {
+        if (controls[0] == 'Transformation 2' && d1.position.distanceTo(d2.position) > 0.5) {
+          confettiState.center(1000);
+        }
+
         return v.clone().multiplyScalar(td1.length() / td2.length());
       } else {
         return v;
@@ -103,18 +111,11 @@
     }
 
     const f4 = new Formula(
-      `\\mathbf{v_1} ${vDistances < 0.1 ? '=' : '\\neq'} \\mathbf{v_2} \\quad T(\\mathbf{v_1}) ${TvDistances < 0.1 ? '=' : '\\neq'} T(\\mathbf{v_2})`
+      `\\mathbf{v_1} ${vDistances < 0.5 ? '=' : '\\neq'} \\mathbf{v_2} \\quad T(\\mathbf{v_1}) ${TvDistances < 0.1 ? '=' : '\\neq'} T(\\mathbf{v_2})`
     );
     formulas.push(f4);
 
     return formulas;
-  });
-
-  $effect(() => {
-    if (vDistances >= 0.5 && TvDistances < 0.1) {
-      // Launch confetti
-      untrack(() => confettiState.center(1000));
-    }
   });
 </script>
 

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example/+page.svelte
@@ -16,10 +16,46 @@
     PrimeColor.blue
   );
 
-  const draggables = [
-    new Draggable(new Vector2(-1, 2), PrimeColor.blue),
-    new Draggable(new Vector2(3, 2), PrimeColor.raspberry)
-  ];
+  const draggables = $derived.by(() => {
+    const d1 = new Draggable(
+      new Vector2(-1, 2),
+      PrimeColor.blue,
+      '',
+      (v) => v,
+      (v) => snapd1(v)
+    );
+    const d2 = new Draggable(
+      new Vector2(3, 2),
+      PrimeColor.raspberry,
+      '',
+      (v) => v,
+      (v) => snapd2(v)
+    );
+
+    function snapd1(v: Vector2) {
+      const td1 = transform(d1.position);
+      const td2 = transform(d2.position);
+
+      if (Math.abs(td1.length() - td2.length()) < 1) {
+        return v.clone().multiplyScalar(td2.length() / td1.length());
+      } else {
+        return v;
+      }
+    }
+
+    function snapd2(v: Vector2) {
+      const td1 = transform(d1.position);
+      const td2 = transform(d2.position);
+
+      if (Math.abs(td1.length() - td2.length()) < 1) {
+        return v.clone().multiplyScalar(td1.length() / td2.length());
+      } else {
+        return v;
+      }
+    }
+
+    return [d1, d2];
+  });
 
   const vDistances = $derived(draggables[0].position.distanceTo(draggables[1].position));
   const TvDistances = $derived(

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example2/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example2/+page.svelte
@@ -16,9 +16,21 @@
     PrimeColor.blue
   );
 
-  const draggables = [new Draggable(new Vector2(3, 2), PrimeColor.blue, '\\mathbf{v}')];
+  const draggables = $derived.by(() => {
+    let snapFn = (v: Vector2) => v;
 
-  const u = new Vector2(2, 1);
+    if (controls[0] === 'Transformation 2') {
+      const solution = new Vector2(70, 17).multiplyScalar(1 / 23);
+      snapFn = (v: Vector2) => (v.distanceTo(solution) < 0.5 ? solution : v);
+    } else if (controls[0] === 'Transformation 3') {
+      const solution = new Vector2(-3, 2);
+      snapFn = (v: Vector2) => (v.distanceTo(solution) < 0.5 ? solution : v);
+    }
+
+    return [new Draggable(new Vector2(3, 2), PrimeColor.blue, '\\mathbf{v}', snapFn)];
+  });
+
+  const u = new Vector2(3, 2);
 
   function transform(vector: Vector2) {
     switch (controls[0]) {
@@ -44,23 +56,25 @@
     switch (controls[0]) {
       case 'Transformation 1':
         const f1 = new Formula(
-          'T(\\mathbf{v})=\\begin{bmatrix}0.8 & -2 \\\\ -0.6 & 1.5 \\end{bmatrix}'
+          'T(\\mathbf{v})=\\begin{bmatrix}0.8 & -2 \\\\ -0.6 & 1.5 \\end{bmatrix}\\mathbf{v}'
         );
         formulas.push(f1);
         break;
       case 'Transformation 2':
         const f2 = new Formula(
-          'T(\\mathbf{v})=\\begin{bmatrix}0.5 & 2 \\\\ 0.9 & -1 \\end{bmatrix}'
+          'T(\\mathbf{v})=\\begin{bmatrix}0.5 & 2 \\\\ 0.9 & -1 \\end{bmatrix}\\mathbf{v}'
         );
         formulas.push(f2);
         break;
       case 'Transformation 3':
-        const f3 = new Formula('T(\\mathbf{v})=\\begin{bmatrix}1 & 3 \\\\ 2 & 4 \\end{bmatrix}');
+        const f3 = new Formula(
+          'T(\\mathbf{v})=\\begin{bmatrix}1 & 3 \\\\ 2 & 4 \\end{bmatrix}\\mathbf{v}'
+        );
         formulas.push(f3);
         break;
     }
 
-    const f4 = new Formula(`T(\\mathbf{v}) ${TvDistances < 0.1 ? '=' : '\\neq'} T(\\mathbf{u})`);
+    const f4 = new Formula(`T(\\mathbf{v}) ${TvDistances < 0.1 ? '=' : '\\neq'} \\mathbf{u}`);
     formulas.push(f4);
 
     return formulas;

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example2/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example2/+page.svelte
@@ -7,7 +7,6 @@
   import { confettiState } from '$lib/stores/confetti.svelte';
   import { Formula } from '$lib/utils/Formulas';
   import { PrimeColor } from '$lib/utils/PrimeColors';
-  import { untrack } from 'svelte';
   import { Vector2 } from 'three';
 
   const controls = Controls.addDropdown(
@@ -21,13 +20,27 @@
 
     if (controls[0] === 'Transformation 1') {
       const solution = new Vector2(70, 17).multiplyScalar(1 / 23);
-      snapFn = (v: Vector2) => (v.distanceTo(solution) < 0.5 ? solution : v);
+      snapFn = (v: Vector2) => {
+        if (v.distanceTo(solution) < 0.5) {
+          confettiState.center(1000);
+          return solution;
+        } else {
+          return v;
+        }
+      };
     } else if (controls[0] === 'Transformation 3') {
       const solution = new Vector2(-3, 2);
-      snapFn = (v: Vector2) => (v.distanceTo(solution) < 0.5 ? solution : v);
+      snapFn = (v: Vector2) => {
+        if (v.distanceTo(solution) < 0.5) {
+          confettiState.center(1000);
+          return solution;
+        } else {
+          return v;
+        }
+      };
     }
 
-    return [new Draggable(new Vector2(3, 2), PrimeColor.blue, '\\mathbf{v}', snapFn)];
+    return [new Draggable(new Vector2(3, 2), PrimeColor.blue, '\\mathbf{v}', (v) => v, snapFn)];
   });
 
   const u = new Vector2(3, 2);
@@ -79,18 +92,17 @@
 
     return formulas;
   });
-
-  $effect(() => {
-    const TvDistances = transform(draggables[0].position).distanceTo(u);
-
-    if (TvDistances < 0.1) {
-      // Launch confetti
-      untrack(() => confettiState.center(1000));
-    }
-  });
 </script>
 
-<Canvas2D {draggables} {formulas} {controls} showFormulasDefault>
+<Canvas2D
+  {draggables}
+  {formulas}
+  {controls}
+  cameraZoom={1.5}
+  cameraPosition={new Vector2(0, 2)}
+  showFormulasDefault
+  splitCanvas2DProps={{ cameraZoom: 1.5, cameraPosition: new Vector2(2, 2) }}
+>
   {#each draggables as draggable}
     <Vector2D
       direction={draggable.position}

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example2/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example2/+page.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { Controls } from '$lib/controls/Controls';
+  import { Draggable } from '$lib/controls/Draggables.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import Latex2D from '$lib/d3/Latex2D.svelte';
+  import Vector2D from '$lib/d3/Vector2D.svelte';
+  import { confettiState } from '$lib/stores/confetti.svelte';
+  import { Formula } from '$lib/utils/Formulas';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { untrack } from 'svelte';
+  import { Vector2 } from 'three';
+
+  const controls = Controls.addDropdown(
+    'Transformation 1',
+    ['Transformation 1', 'Transformation 2', 'Transformation 3'],
+    PrimeColor.blue
+  );
+
+  const draggables = [new Draggable(new Vector2(3, 2), PrimeColor.blue, '\\mathbf{v}')];
+
+  const u = new Vector2(2, 1);
+
+  function transform(vector: Vector2) {
+    switch (controls[0]) {
+      case 'Transformation 1':
+        // Transform 1 - with the matrix [0.8 -2; -0.6 1.5]
+        return new Vector2(0.8 * vector.x - 2 * vector.y, -0.6 * vector.x + 1.5 * vector.y);
+      case 'Transformation 2':
+        // Transform 2 - with the matrix [0.5 2; 0.9 -1]
+        return new Vector2(0.5 * vector.x + 2 * vector.y, 0.9 * vector.x - vector.y);
+      case 'Transformation 3':
+        // Transform 3 - with the matrix [1 3; 2 4]
+        return new Vector2(vector.x + 3 * vector.y, 2 * vector.x + 4 * vector.y);
+      default:
+        return vector;
+    }
+  }
+
+  const formulas = $derived.by(() => {
+    let formulas = [];
+
+    const TvDistances = transform(draggables[0].position).distanceTo(u);
+
+    switch (controls[0]) {
+      case 'Transformation 1':
+        const f1 = new Formula(
+          'T(\\mathbf{v})=\\begin{bmatrix}0.8 & -2 \\\\ -0.6 & 1.5 \\end{bmatrix}'
+        );
+        formulas.push(f1);
+        break;
+      case 'Transformation 2':
+        const f2 = new Formula(
+          'T(\\mathbf{v})=\\begin{bmatrix}0.5 & 2 \\\\ 0.9 & -1 \\end{bmatrix}'
+        );
+        formulas.push(f2);
+        break;
+      case 'Transformation 3':
+        const f3 = new Formula('T(\\mathbf{v})=\\begin{bmatrix}1 & 3 \\\\ 2 & 4 \\end{bmatrix}');
+        formulas.push(f3);
+        break;
+    }
+
+    const f4 = new Formula(`T(\\mathbf{v}) ${TvDistances < 0.1 ? '=' : '\\neq'} T(\\mathbf{u})`);
+    formulas.push(f4);
+
+    return formulas;
+  });
+
+  $effect(() => {
+    const TvDistances = transform(draggables[0].position).distanceTo(u);
+
+    if (TvDistances < 0.1) {
+      // Launch confetti
+      untrack(() => confettiState.center(1000));
+    }
+  });
+</script>
+
+<Canvas2D {draggables} {formulas} {controls} showFormulasDefault>
+  {#each draggables as draggable}
+    <Vector2D
+      direction={draggable.position}
+      length={draggable.position.length()}
+      color={draggable.color}
+    />
+  {/each}
+
+  {#snippet splitCanvas2DChildren()}
+    <Vector2D direction={u} length={u.length()} color={PrimeColor.raspberry} />
+    <Latex2D position={u} color={PrimeColor.raspberry} latex={'\\mathbf{u}'} />
+
+    {#each draggables as draggable}
+      {@const transformed = transform(draggable.position)}
+      <Vector2D direction={transformed} length={transformed.length()} color={draggable.color} />
+
+      <Latex2D
+        position={transformed}
+        offset={new Vector2(-0.2, 0.3)}
+        latex={'T(\\mathbf{v})'}
+        color={draggable.color}
+        extend={0.3}
+      />
+    {/each}
+  {/snippet}
+</Canvas2D>

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example2/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example2/+page.svelte
@@ -19,7 +19,7 @@
   const draggables = $derived.by(() => {
     let snapFn = (v: Vector2) => v;
 
-    if (controls[0] === 'Transformation 2') {
+    if (controls[0] === 'Transformation 1') {
       const solution = new Vector2(70, 17).multiplyScalar(1 / 23);
       snapFn = (v: Vector2) => (v.distanceTo(solution) < 0.5 ? solution : v);
     } else if (controls[0] === 'Transformation 3') {
@@ -35,11 +35,11 @@
   function transform(vector: Vector2) {
     switch (controls[0]) {
       case 'Transformation 1':
-        // Transform 1 - with the matrix [0.8 -2; -0.6 1.5]
-        return new Vector2(0.8 * vector.x - 2 * vector.y, -0.6 * vector.x + 1.5 * vector.y);
-      case 'Transformation 2':
         // Transform 2 - with the matrix [0.5 2; 0.9 -1]
         return new Vector2(0.5 * vector.x + 2 * vector.y, 0.9 * vector.x - vector.y);
+      case 'Transformation 2':
+        // Transform 1 - with the matrix [0.8 -2; -0.6 1.5]
+        return new Vector2(0.8 * vector.x - 2 * vector.y, -0.6 * vector.x + 1.5 * vector.y);
       case 'Transformation 3':
         // Transform 3 - with the matrix [1 3; 2 4]
         return new Vector2(vector.x + 3 * vector.y, 2 * vector.x + 4 * vector.y);
@@ -55,16 +55,16 @@
 
     switch (controls[0]) {
       case 'Transformation 1':
-        const f1 = new Formula(
-          'T(\\mathbf{v})=\\begin{bmatrix}0.8 & -2 \\\\ -0.6 & 1.5 \\end{bmatrix}\\mathbf{v}'
-        );
-        formulas.push(f1);
-        break;
-      case 'Transformation 2':
         const f2 = new Formula(
           'T(\\mathbf{v})=\\begin{bmatrix}0.5 & 2 \\\\ 0.9 & -1 \\end{bmatrix}\\mathbf{v}'
         );
         formulas.push(f2);
+        break;
+      case 'Transformation 2':
+        const f1 = new Formula(
+          'T(\\mathbf{v})=\\begin{bmatrix}0.8 & -2 \\\\ -0.6 & 1.5 \\end{bmatrix}\\mathbf{v}'
+        );
+        formulas.push(f1);
         break;
       case 'Transformation 3':
         const f3 = new Formula(

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex/+page.svelte
@@ -18,7 +18,9 @@
   }
 
   const formulas = $derived.by(() => {
-    const f1 = new Formula('T(\\mathbf{v})=\\begin{bmatrix}1 & -1 \\\\ 1 & 1 \\end{bmatrix}');
+    const f1 = new Formula(
+      'T(\\mathbf{v})=\\begin{bmatrix}1 & -1 \\\\ 1 & 1 \\end{bmatrix}\\mathbf{v}'
+    );
 
     return [f1];
   });

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex/+page.svelte
@@ -26,7 +26,14 @@
   });
 </script>
 
-<Canvas2D {draggables} {formulas} showFormulasDefault>
+<Canvas2D
+  {draggables}
+  {formulas}
+  showFormulasDefault
+  cameraZoom={1.75}
+  cameraPosition={new Vector2(0, 2)}
+  splitCanvas2DProps={{ cameraZoom: 1.75, cameraPosition: new Vector2(0, 2) }}
+>
   {#each draggables as draggable}
     <Vector2D
       direction={draggable.position}

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex/+page.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { Draggable } from '$lib/controls/Draggables.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import Latex2D from '$lib/d3/Latex2D.svelte';
+  import Vector2D from '$lib/d3/Vector2D.svelte';
+  import { Formula } from '$lib/utils/Formulas';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+
+  const draggables = [
+    new Draggable(new Vector2(2, 1), PrimeColor.blue, '\\mathbf{v_1}'),
+    new Draggable(new Vector2(-1, 2), PrimeColor.raspberry, '\\mathbf{v_2}')
+  ];
+
+  function transform(vector: Vector2) {
+    // Transform with the matrix [1 -1; 1 1]
+    return new Vector2(vector.x - vector.y, vector.x + vector.y);
+  }
+
+  const formulas = $derived.by(() => {
+    const f1 = new Formula('T(\\mathbf{v})=\\begin{bmatrix}1 & -1 \\\\ 1 & 1 \\end{bmatrix}');
+
+    return [f1];
+  });
+</script>
+
+<Canvas2D {draggables} {formulas}>
+  {#each draggables as draggable}
+    <Vector2D
+      direction={draggable.position}
+      length={draggable.position.length()}
+      color={draggable.color}
+    />
+  {/each}
+
+  {#snippet splitCanvas2DChildren()}
+    {#each draggables as draggable}
+      {@const transformed = transform(draggable.position)}
+      <Vector2D direction={transformed} length={transformed.length()} color={draggable.color} />
+
+      <Latex2D
+        position={transformed}
+        offset={new Vector2(0.2, -0.3)}
+        latex={'T(\\mathbf{v})'}
+        color={draggable.color}
+        extend={0.3}
+      />
+    {/each}
+  {/snippet}
+</Canvas2D>

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-nonsurjex/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-nonsurjex/+page.svelte
@@ -1,24 +1,22 @@
 <script lang="ts">
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';
   import Latex2D from '$lib/d3/Latex2D.svelte';
   import Vector2D from '$lib/d3/Vector2D.svelte';
   import { Formula } from '$lib/utils/Formulas';
   import { PrimeColor } from '$lib/utils/PrimeColors';
   import { Vector2 } from 'three';
 
-  const draggables = [
-    new Draggable(new Vector2(2, 1), PrimeColor.blue, '\\mathbf{v_1}'),
-    new Draggable(new Vector2(-1, 2), PrimeColor.raspberry, '\\mathbf{v_2}')
-  ];
+  const draggables = [new Draggable(new Vector2(2, 1), PrimeColor.blue, '\\mathbf{v}')];
 
   function transform(vector: Vector2) {
-    // Transform with the matrix [1 -1; 1 1]
-    return new Vector2(vector.x - vector.y, vector.x + vector.y);
+    // Transform with the matrix [1 -1; -1 1]
+    return new Vector2(vector.x - vector.y, -vector.x + vector.y);
   }
 
   const formulas = $derived.by(() => {
-    const f1 = new Formula('T(\\mathbf{v})=\\begin{bmatrix}1 & -1 \\\\ 1 & 1 \\end{bmatrix}');
+    const f1 = new Formula('T(\\mathbf{v})=\\begin{bmatrix}1 & -1 \\\\ -1 & 1 \\end{bmatrix}');
 
     return [f1];
   });
@@ -34,14 +32,16 @@
   {/each}
 
   {#snippet splitCanvas2DChildren()}
-    {#each draggables as draggable, index}
+    <InfiniteLine2D direction={new Vector2(1, -1)} color={PrimeColor.darkGreen} />
+
+    {#each draggables as draggable}
       {@const transformed = transform(draggable.position)}
       <Vector2D direction={transformed} length={transformed.length()} color={draggable.color} />
 
       <Latex2D
         position={transformed}
-        offset={new Vector2(-0.2, 0.3)}
-        latex={`T(\\mathbf{v_${index + 1}})`}
+        offset={new Vector2(0, 0.5)}
+        latex={'T(\\mathbf{v})'}
         color={draggable.color}
         extend={0.3}
       />

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-nonsurjex/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-nonsurjex/+page.svelte
@@ -16,7 +16,9 @@
   }
 
   const formulas = $derived.by(() => {
-    const f1 = new Formula('T(\\mathbf{v})=\\begin{bmatrix}1 & -1 \\\\ -1 & 1 \\end{bmatrix}');
+    const f1 = new Formula(
+      'T(\\mathbf{v})=\\begin{bmatrix}1 & -1 \\\\ -1 & 1 \\end{bmatrix}\\mathbf{v}'
+    );
 
     return [f1];
   });

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-nonsurjex/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-nonsurjex/+page.svelte
@@ -24,7 +24,13 @@
   });
 </script>
 
-<Canvas2D {draggables} {formulas} showFormulasDefault>
+<Canvas2D
+  cameraZoom={2}
+  splitCanvas2DProps={{ cameraZoom: 2 }}
+  {draggables}
+  {formulas}
+  showFormulasDefault
+>
   {#each draggables as draggable}
     <Vector2D
       direction={draggable.position}


### PR DESCRIPTION
Four applets that showcase the functionality of Injective subjective

Links to all applets:
> [injsurj-injex](https://deploy-preview-266--playful-otter-9e0500.netlify.app/applet/injectivity_and_surjectivity/injsurj-injex)
> [injsurj-indjex-example](https://deploy-preview-266--playful-otter-9e0500.netlify.app/applet/injectivity_and_surjectivity/injsurj-injex-example)
> [injsurj-injex-example2](https://deploy-preview-266--playful-otter-9e0500.netlify.app/applet/injectivity_and_surjectivity/injsurj-injex-example2)
>[injsurj-nonsurjex](https://deploy-preview-266--playful-otter-9e0500.netlify.app/applet/injectivity_and_surjectivity/injsurj-nonsurjex)

<img width="694" alt="Screenshot 2024-10-14 at 14 40 55" src="https://github.com/user-attachments/assets/39e4d9cd-206d-431b-b289-b23d380b9c8f">

<img width="702" alt="Screenshot 2024-10-14 at 14 41 02" src="https://github.com/user-attachments/assets/81289185-2a80-48a1-a772-6ce673f1eaef">

closes #267 