### PR TITLE
Fix path rendering position in Trajectory2D component

### DIFF
--- a/src/lib/d3/Trajectory2D.svelte
+++ b/src/lib/d3/Trajectory2D.svelte
@@ -118,6 +118,6 @@
       />
     </g>
   {/if}
-
-  <path d={smoothLine} stroke={color ?? 'black'} stroke-width={width ?? LINE_WIDTH} fill="none" />
 {/each}
+
+<path d={smoothLine} stroke={color ?? 'black'} stroke-width={width ?? LINE_WIDTH} fill="none" />


### PR DESCRIPTION
accidently rendered paths 50ish times while once was also fine