### PR TITLE
Fix LaTeX formatting for vector norms

### DIFF
--- a/src/routes/applet/dot_product/diagonal_parallelogram/+page.svelte
+++ b/src/routes/applet/dot_product/diagonal_parallelogram/+page.svelte
@@ -40,21 +40,21 @@
 
   const formulas = [
     new Formula(`{\\$1} = \\$2`)
-      .addParam(1, ' | \\mathbf{v + w} |', PrimeColor.raspberry)
-      .addParam(2, '|\\mathbf{v - w}|', PrimeColor.orange)
+      .addParam(1, '\\| \\mathbf{v + w} \\|', PrimeColor.raspberry)
+      .addParam(2, '\\|\\mathbf{v - w}\\|', PrimeColor.orange)
   ];
 
   const splitFormulas = $derived.by(() => {
-    const plus = ' | \\mathbf{v + w} |';
-    const min = '|\\mathbf{v - w}|';
+    const plus = ' \\| \\mathbf{v + w} \\|';
+    const min = '\\|\\mathbf{v - w}\\|';
 
     const f1 = new Formula(`\\$1 ${isOrthogonal ? '=' : '\\neq'} \\$2`)
       .addParam(1, plus, PrimeColor.raspberry)
       .addParam(2, min, PrimeColor.orange);
 
     const f2 = new Formula(`\\$1 \\cdot \\$2 = \\$3`)
-      .addParam(1, '|\\mathbf{v}|', PrimeColor.blue)
-      .addParam(2, '|\\mathbf{w}|', PrimeColor.darkGreen)
+      .addParam(1, '\\|\\mathbf{v}\\|', PrimeColor.blue)
+      .addParam(2, '\\|\\mathbf{w}\\|', PrimeColor.darkGreen)
       .addParam(3, round(w.dot(v)), PrimeColor.raspberry);
 
     return [f1, f2];


### PR DESCRIPTION
This pull request updates the mathematical notation in the `diagonal_parallelogram` applet to consistently use the correct LaTeX syntax for vector norms (double vertical bars) throughout the formulas.

**Math notation consistency:**

* Updated all instances of vector norm notation in formulas from single vertical bars (e.g., `|\mathbf{v}|`) to double vertical bars (e.g., `\|\mathbf{v}\|`) for better clarity and mathematical correctness in `+page.svelte`.