### PR TITLE
Fixed slider label overlapping

### DIFF
--- a/src/lib/components/controls/Slider.svelte
+++ b/src/lib/components/controls/Slider.svelte
@@ -153,7 +153,7 @@
   </Button.Action>
 
   {#if slider.label}
-    <div class="flex flex-col ml-4 mr-2">
+    <div class="mr-2 ml-4 flex flex-col">
       <Label
         class="relative flex w-fit items-center gap-1 pr-1 text-xs text-slate-700"
         for="range-{uuid}"

--- a/src/lib/components/controls/Slider.svelte
+++ b/src/lib/components/controls/Slider.svelte
@@ -153,30 +153,44 @@
   </Button.Action>
 
   {#if slider.label}
-    <Label
-      class="relative flex w-fit items-center gap-1 pr-1 text-xs text-slate-700"
-      for="range-{uuid}"
-      >{slider.label}:
-      <p class="absolute left-full flex text-sm" style="color:{slider.color};">
-        {#if slider.labelFormat}
-          {@render slider.labelFormat(value)}
-        {:else}
-          {label}
-        {/if}
-      </p>
-    </Label>
+    <div class="flex flex-col ml-4 mr-2">
+      <Label
+        class="relative flex w-fit items-center gap-1 pr-1 text-xs text-slate-700"
+        for="range-{uuid}"
+        >{slider.label}:
+        <p class="absolute left-full flex text-sm" style="color:{slider.color};">
+          {#if slider.labelFormat}
+            {@render slider.labelFormat(value)}
+          {:else}
+            {label}
+          {/if}
+        </p>
+      </Label>
+      <input
+        type="range"
+        id="range-{uuid}"
+        min={slider.min}
+        max={slider.max}
+        step={slider.stepSize}
+        bind:value
+        onchange={stopPlaying}
+        onmousedown={startChanging}
+        ontouchstart={startChanging}
+        style="accent-color: {slider.color}"
+      />
+    </div>
+  {:else}
+    <input
+      type="range"
+      id="range-{uuid}"
+      min={slider.min}
+      max={slider.max}
+      step={slider.stepSize}
+      bind:value
+      onchange={stopPlaying}
+      onmousedown={startChanging}
+      ontouchstart={startChanging}
+      style="accent-color: {slider.color}"
+    />
   {/if}
-
-  <input
-    type="range"
-    id="range-{uuid}"
-    min={slider.min}
-    max={slider.max}
-    step={slider.stepSize}
-    bind:value
-    onchange={stopPlaying}
-    onmousedown={startChanging}
-    ontouchstart={startChanging}
-    style="accent-color: {slider.color}"
-  />
 {/if}


### PR DESCRIPTION
I found that the slider labels overlap with the slider input with the new minimize button.

Before the fix:

<img width="290" height="81" alt="image" src="https://github.com/user-attachments/assets/74f80e27-dbf8-4d44-87ed-1f7c2059e1f3" />

After:

<img width="278" height="68" alt="image" src="https://github.com/user-attachments/assets/a5640a41-f176-487e-8bcc-ac21ed36f92f" />
