### PR TITLE
Update diagonal matrix values in quadratic forms

### DIFF
--- a/src/routes/applet/symmetric_matrices/quadratic_forms/+page.svelte
+++ b/src/routes/applet/symmetric_matrices/quadratic_forms/+page.svelte
@@ -26,7 +26,7 @@
     return [f];
   });
 
-  const mat = new DiagonalMatrix(new Matrix2(1, 0.5, 0.5, 1), 'A', PrimeColor.orange, 0.5);
+  const mat = new DiagonalMatrix(new Matrix2(3, 2, 2, 6), 'A', PrimeColor.orange, 0.5);
 
   const controls = $derived.by(() => {
     return Controls.add(mat).addSlider(3, -10, 10, 0.1, PrimeColor.raspberry, {


### PR DESCRIPTION
This pull request updates the initialization of the matrix used in the quadratic forms applet. The change modifies the values of the `Matrix2` instance to use new parameters, which will affect the behavior and appearance of the matrix in the applet.

Matrix initialization update:

* Changed the `Matrix2` values in the construction of `mat` from `(1, 0.5, 0.5, 1)` to `(3, 2, 2, 6)` in `src/routes/applet/symmetric_matrices/quadratic_forms/+page.svelte`, altering the matrix used for quadratic form calculations and visualizations.