### PR TITLE
Fixes overflow in Canvas3d with split scenes

### DIFF
--- a/src/lib/threlte/Canvas3D.svelte
+++ b/src/lib/threlte/Canvas3D.svelte
@@ -118,7 +118,7 @@
 >
   {#snippet sceneChildren(width, height)}
     {@const canvasWidth = hasSplitCanvas ? width / 2 : width}
-    <div style="width: {canvasWidth}px" class="overflow">
+    <div style="width: {canvasWidth}px" class="overflow-hidden">
       {#if confettiState.confettiSide === 'left' || confettiState.confettiSide === 'center'}
         <Confetti isSplit={false} />
       {/if}


### PR DESCRIPTION
I also noticed there is a `gap-3` (in Scene) between the split scenes that leaves empty space in the middle, but I think that's intentional?

Before
<img width="381" height="310" alt="image" src="https://github.com/user-attachments/assets/8d06de6e-52f5-4248-a258-876ee677520d" />

After
<img width="381" height="310" alt="image" src="https://github.com/user-attachments/assets/3a2b484a-3a5b-4f0d-9d3a-4a93b683ab48" />
