### PR TITLE
Truncate text that wont fit in Dropdown

### DIFF
--- a/src/lib/components/ui/select/select-trigger.svelte
+++ b/src/lib/components/ui/select/select-trigger.svelte
@@ -27,5 +27,5 @@
   <span class="truncate">
     {@render children?.()}
   </span>
-  <ChevronDownIcon class="size-4 opacity-50 shrink-0" />
+  <ChevronDownIcon class="size-4 shrink-0 opacity-50" />
 </SelectPrimitive.Trigger>


### PR DESCRIPTION
Solves #309 

However, now many of the labels will be truncated. Maybe we shuold move away from the preset width of the Dropdown?

<img width="594" height="120" alt="image" src="https://github.com/user-attachments/assets/d05f0bf9-2aaf-45c3-8a85-4b770cc9741a" />

<img width="594" height="120" alt="image" src="https://github.com/user-attachments/assets/9f0cf964-9160-4274-9afe-964427d7b66b" />
