### PR TITLE
Enforce translation keys for title attributes

### DIFF
--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -1,0 +1,55 @@
+/**
+ * Custom ESLint rules for the Open-LA-Applets project
+ */
+
+export default {
+  'no-hardcoded-title': {
+    meta: {
+      type: 'problem',
+      docs: {
+        description: 'Disallow hardcoded strings in title attributes, require translation keys',
+        category: 'Best Practices',
+        recommended: true
+      },
+      messages: {
+        hardcodedTitle:
+          'Hardcoded string "{{value}}" in title attribute. Use a translation key instead: title={$_(\'applets...\')}'
+      },
+      schema: []
+    },
+    create(context) {
+      return {
+        SvelteAttribute(node) {
+          if (node.key?.name !== 'title') {
+            return;
+          }
+
+          if (node.value && node.value.length > 0) {
+            const value = node.value[0];
+
+            if (value.type === 'SvelteLiteral' || value.type === 'Literal') {
+              context.report({
+                node,
+                messageId: 'hardcodedTitle',
+                data: {
+                  value: value.value
+                }
+              });
+            }
+
+            if (value.type === 'SvelteMustacheTag') {
+              const expression = value.expression;
+
+              if (expression?.type === 'CallExpression') {
+                const callee = expression.callee;
+                if (callee?.type === 'Identifier' && callee.name === '$_') {
+                  return; // valid
+                }
+              }
+            }
+          }
+        }
+      };
+    }
+  }
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,7 @@ import globals from 'globals';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript-eslint';
 import svelteConfig from './svelte.config.js';
+import localRules from './eslint-local-rules.js';
 
 const gitignorePath = fileURLToPath(new URL('./.gitignore', import.meta.url));
 
@@ -23,6 +24,11 @@ export default ts.config(
     languageOptions: {
       globals: { ...globals.browser, ...globals.node }
     },
+    plugins: {
+      'local-rules': {
+        rules: localRules
+      }
+    },
     rules: {
       'no-undef': 'off',
       '@typescript-eslint/no-unused-vars': [
@@ -36,7 +42,8 @@ export default ts.config(
           varsIgnorePattern: '^_',
           ignoreRestSiblings: true
         }
-      ]
+      ],
+      'local-rules/no-hardcoded-title': 'error'
     }
   },
   {
@@ -48,6 +55,13 @@ export default ts.config(
         parser: ts.parser,
         svelteConfig
       }
+    }
+  },
+  // Disable hardcoded title rule for tutorials and stories
+  {
+    files: ['**/tutorial*/**/*.svelte', '**/stories/**/*.svelte'],
+    rules: {
+      'local-rules/no-hardcoded-title': 'off'
     }
   },
   storybook.configs['flat/recommended']


### PR DESCRIPTION
Added a lint rule to check if applets are using translation keys (only in title). Checking elsewhere is not possible, but this should help us remember to use translation keys.