### PR TITLE
Add interactive calculus applets for limits at a point

### DIFF
--- a/src/routes/applet/calculus/limits_at_a_point/a_function_with_two_vertical_asymptotes/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/a_function_with_two_vertical_asymptotes/+page.svelte
@@ -60,6 +60,16 @@
       shape: 'circle',
       legendText: 'f(x)=\\frac{1}{(x-1)(x-2)^2}'
     }),
+    new FunctionFragment('', PrimeColor.raspberry, {
+      isDashed: true,
+      shape: 'triangle',
+      legendText: 'x=1'
+    }),
+    new FunctionFragment('', PrimeColor.darkGreen, {
+      isDashed: true,
+      shape: 'triangle',
+      legendText: 'x=2'
+    }),
     new AsymptoteFragment(2, 'vertical', PrimeColor.raspberry),
     new AsymptoteFragment(1, 'vertical', PrimeColor.darkGreen)
   ];

--- a/src/routes/applet/calculus/limits_at_a_point/a_function_with_two_vertical_asymptotes/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/a_function_with_two_vertical_asymptotes/+page.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
+  import {
+    AppletObject,
+    AsymptoteFragment,
+    FunctionFragment,
+    ObliqueAsymptoteFragment
+  } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import Axis from '$lib/d3/Axis.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import { toLatexText } from '$lib/utils/FormatString';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(3, 1);
+  cameraZoom = 1.5;
+
+  // (remove if unnecessary)
+  initialViewBox = new ViewBox(
+    new Vector2(-2, -2), // bottom-left
+    new Vector2(6, 6), // top-right
+    0.5 // margin
+  );
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment('\\frac{1}{(x-1)(x-2)^2}/3', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      legendText: 'f(x)=\\frac{1}{(x-1)(x-2)^2}'
+    }),
+    new AsymptoteFragment(2, 'vertical', PrimeColor.raspberry),
+    new AsymptoteFragment(1, 'vertical', PrimeColor.darkGreen)
+  ];
+</script>
+
+<Canvas2D
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={getLegend(appletObjects)}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+  axis={null}
+>
+  <TemplateComponent objects={appletObjects} />
+  <Axis scaleY={1 / 3} />
+</Canvas2D>

--- a/src/routes/applet/calculus/limits_at_a_point/limit_of_sign_function_near_0/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/limit_of_sign_function_near_0/+page.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
+  import {
+    AppletObject,
+    AsymptoteFragment,
+    FunctionFragment,
+    ObliqueAsymptoteFragment
+  } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import Axis from '$lib/d3/Axis.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import { toLatexText } from '$lib/utils/FormatString';
+  import { Controls } from '$lib/controls/Controls';
+  import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(3, 1);
+  cameraZoom = 1.5;
+
+  // (remove if unnecessary)
+  initialViewBox = new ViewBox(
+    new Vector2(-4, -4), // bottom-left
+    new Vector2(4, 4), // top-right
+    0.5 // margin
+  );
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const controls = Controls.addSlider(1.5, 0.05, 8, 0.05, PrimeColor.orange, {
+    label: 'ε'
+  }).addSlider(1, 0.05, 8, 0.05, PrimeColor.raspberry, { label: 'δ' });
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment('\\frac{|x|}{x}', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      legendText: 'f(x)=\\frac{|x|}{x}',
+      domain: { xMax: 0 }
+    }).addGaps([new Vector2(0, 1), new Vector2(0, -1)]),
+    new FunctionFragment('\\frac{|x|}{x}', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      domain: { xMin: 0 }
+    }),
+    new FunctionFragment('', PrimeColor.raspberry, {
+      isDashed: true,
+      shape: 'triangle',
+      legendText: 'x=\\pm\\delta'
+    }),
+    new FunctionFragment('', PrimeColor.orange, {
+      isDashed: true,
+      shape: 'triangle',
+      legendText: 'y=\\pm\\varepsilon'
+    })
+  ];
+</script>
+
+<Canvas2D
+  {controls}
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={getLegend(appletObjects)}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+>
+  <TemplateComponent objects={appletObjects} />
+  <InfiniteLine2D
+    direction={new Vector2(1, 0)}
+    origin={new Vector2(0, controls[0])}
+    color={PrimeColor.orange}
+    isDashed={true}
+  />
+  <InfiniteLine2D
+    direction={new Vector2(1, 0)}
+    origin={new Vector2(0, -controls[0])}
+    color={PrimeColor.orange}
+    isDashed={true}
+  />
+  <InfiniteLine2D
+    direction={new Vector2(0, 1)}
+    origin={new Vector2(controls[1], 0)}
+    color={PrimeColor.darkGreen}
+    isDashed={true}
+  />
+  <InfiniteLine2D
+    direction={new Vector2(0, 1)}
+    origin={new Vector2(-controls[1], 0)}
+    color={PrimeColor.darkGreen}
+    isDashed={true}
+  />
+</Canvas2D>

--- a/src/routes/applet/calculus/limits_at_a_point/limit_of_x_squared_near_2/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/limit_of_x_squared_near_2/+page.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
+  import {
+    AppletObject,
+    AsymptoteFragment,
+    FunctionFragment,
+    ObliqueAsymptoteFragment
+  } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import Axis from '$lib/d3/Axis.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import { toLatexText } from '$lib/utils/FormatString';
+  import { Controls } from '$lib/controls/Controls';
+  import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(3, 1);
+  cameraZoom = 1.5;
+
+  // (remove if unnecessary)
+  initialViewBox = new ViewBox(
+    new Vector2(-1, -1), // bottom-left
+    new Vector2(7, 6), // top-right
+    0.5 // margin
+  );
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const controls = Controls.addSlider(1, 0.05, 8, 0.05, PrimeColor.orange, {
+    label: 'ε'
+  });
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment('x^2', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'square',
+      legendText: 'f(x)=x^2'
+    }),
+    new FunctionFragment('', PrimeColor.darkGreen, {
+      isDashed: false,
+      shape: 'circle',
+      legendText: '\\left(2,4\\right)'
+    }).addIncludedPoints(new Vector2(2, 4)),
+    new FunctionFragment('', PrimeColor.raspberry, {
+      isDashed: true,
+      shape: 'triangle',
+      legendText: 'x=2\\pm\\delta'
+    }),
+    new FunctionFragment('', PrimeColor.orange, {
+      isDashed: true,
+      shape: 'triangle',
+      legendText: 'y=4\\pm\\varepsilon'
+    })
+  ];
+  let delta = $derived(
+    controls[0] > 4
+      ? Math.min(2, Math.sqrt(4 + controls[0]) - 2)
+      : Math.min(2 - Math.sqrt(4 - controls[0]), Math.sqrt(4 + controls[0]) - 2)
+  );
+</script>
+
+<Canvas2D
+  {controls}
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={getLegend(appletObjects)}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+>
+  <TemplateComponent objects={appletObjects} />
+  <InfiniteLine2D
+    direction={new Vector2(1, 0)}
+    origin={new Vector2(0, 4 + controls[0])}
+    color={PrimeColor.orange}
+    isDashed={true}
+  />
+  <InfiniteLine2D
+    direction={new Vector2(1, 0)}
+    origin={new Vector2(0, 4 - controls[0])}
+    color={PrimeColor.orange}
+    isDashed={true}
+  />
+  <InfiniteLine2D
+    direction={new Vector2(0, 1)}
+    origin={new Vector2(2 + delta, 0)}
+    color={PrimeColor.darkGreen}
+    isDashed={true}
+  />
+  <InfiniteLine2D
+    direction={new Vector2(0, 1)}
+    origin={new Vector2(2 - delta, 0)}
+    color={PrimeColor.darkGreen}
+    isDashed={true}
+  />
+</Canvas2D>

--- a/src/routes/applet/calculus/limits_at_a_point/one_over_x_squared/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/one_over_x_squared/+page.svelte
@@ -13,6 +13,7 @@
   import { ViewBox } from '$lib/d3/ViewBox';
   import { getLegend } from '$lib/template/ObjectFormulas';
   import { toLatexText } from '$lib/utils/FormatString';
+  import Function from '$lib/components/controls/Function.svelte';
 
   let initialViewBox: ViewBox | undefined;
   let cameraPosition: Vector2 | undefined;
@@ -58,7 +59,13 @@
       isDashed: false,
       shape: 'circle',
       legendText: 'f(x)=\\frac{1}{x^2}'
-    })
+    }),
+    new FunctionFragment('', PrimeColor.raspberry, {
+      isDashed: true,
+      shape: 'triangle',
+      legendText: 'x=0'
+    }),
+    new AsymptoteFragment(0, 'vertical', PrimeColor.raspberry)
   ];
 </script>
 

--- a/src/routes/applet/calculus/limits_at_a_point/one_over_x_squared/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/one_over_x_squared/+page.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
+  import {
+    AppletObject,
+    AsymptoteFragment,
+    FunctionFragment,
+    ObliqueAsymptoteFragment
+  } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import { toLatexText } from '$lib/utils/FormatString';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(3, 1);
+  cameraZoom = 1.5;
+
+  // (remove if unnecessary)
+  initialViewBox = new ViewBox(
+    new Vector2(-4, -1), // bottom-left
+    new Vector2(4, 7), // top-right
+    0.5 // margin
+  );
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment('\\frac{1}{x^2}', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      legendText: 'f(x)=\\frac{1}{x^2}'
+    })
+  ];
+</script>
+
+<Canvas2D
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={getLegend(appletObjects)}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+>
+  <TemplateComponent objects={appletObjects} />
+</Canvas2D>

--- a/src/routes/applet/calculus/limits_at_a_point/piecewise_function/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/piecewise_function/+page.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
+  import {
+    AppletObject,
+    AsymptoteFragment,
+    FunctionFragment,
+    ObliqueAsymptoteFragment
+  } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import { toLatexText } from '$lib/utils/FormatString';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(3, 1);
+  cameraZoom = 1.5;
+
+  // (remove if unnecessary)
+  initialViewBox = new ViewBox(
+    new Vector2(-2, -2), // bottom-left
+    new Vector2(6, 6), // top-right
+    0.5 // margin
+  );
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment('x-1', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      legendText:
+        'f(x)=\\left\\{\\begin{array}{ll}x-1,&\\text{ if }x<2,\\\\ 4,&\\text{ if }x=2,\\\\ 3-x,&\\text{ if }x>2.\\end{array}\\right.',
+      domain: { xMax: 2 }
+    })
+      .addGaps([new Vector2(2, 1)])
+      .addIncludedPoints([new Vector2(2, 4)]),
+    new FunctionFragment('3-x', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      domain: { xMin: 2 }
+    })
+  ];
+</script>
+
+<Canvas2D
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={getLegend(appletObjects)}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+>
+  <TemplateComponent objects={appletObjects} />
+</Canvas2D>

--- a/src/routes/applet/calculus/limits_at_a_point/rounding_to_integers/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/rounding_to_integers/+page.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
+  import {
+    AppletObject,
+    AsymptoteFragment,
+    FunctionFragment,
+    ObliqueAsymptoteFragment
+  } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import { toLatexText } from '$lib/utils/FormatString';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(3, 1);
+  cameraZoom = 1.5;
+
+  // (remove if unnecessary)
+  initialViewBox = new ViewBox(
+    new Vector2(-1, -2), // bottom-left
+    new Vector2(7, 8), // top-right
+    0.5 // margin
+  );
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment('-30', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      legendText: 'f(x)',
+      domain: { xMin: -30, xMax: -30 + 0.5 }
+    }).addGaps(new Vector2(-30 + 0.5, -30))
+  ];
+  for (let i = -29; i < 30; i++) {
+    appletObjects.push(
+      new FunctionFragment(i.toString(), PrimeColor.blue, {
+        isDashed: false,
+        shape: 'circle',
+        domain: { xMin: i - 0.5, xMax: i + 0.5 }
+      })
+        .addGaps(new Vector2(i + 0.5, i))
+        .addIncludedPoints(new Vector2(i - 0.5, i))
+    );
+  }
+  appletObjects.push(
+    new FunctionFragment('30', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      domain: { xMin: 30 - 0.5, xMax: 30 }
+    }).addIncludedPoints(new Vector2(30 - 0.5, 30))
+  );
+</script>
+
+<Canvas2D
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={getLegend(appletObjects)}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+>
+  <TemplateComponent objects={appletObjects} />
+</Canvas2D>

--- a/src/routes/applet/calculus/limits_at_a_point/sign_function/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/sign_function/+page.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
+  import {
+    AppletObject,
+    AsymptoteFragment,
+    FunctionFragment,
+    ObliqueAsymptoteFragment
+  } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import { toLatexText } from '$lib/utils/FormatString';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(3, 1);
+  cameraZoom = 1.5;
+
+  // (remove if unnecessary)
+  initialViewBox = new ViewBox(
+    new Vector2(-4, -4), // bottom-left
+    new Vector2(4, 4), // top-right
+    0.5 // margin
+  );
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment('\\frac{|x|}{x}', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      legendText: 'f(x)=\\frac{|x|}{x}',
+      domain: { xMax: 0 }
+    }).addGaps([new Vector2(0, 1), new Vector2(0, -1)]),
+    new FunctionFragment('\\frac{|x|}{x}', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      domain: { xMin: 0 }
+    })
+  ];
+</script>
+
+<Canvas2D
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={getLegend(appletObjects)}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+>
+  <TemplateComponent objects={appletObjects} />
+</Canvas2D>

--- a/src/routes/applet/calculus/limits_at_a_point/sine_of_one_over_x/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/sine_of_one_over_x/+page.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
+  import {
+    AppletObject,
+    AsymptoteFragment,
+    FunctionFragment,
+    ObliqueAsymptoteFragment
+  } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import { toLatexText } from '$lib/utils/FormatString';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(0, 0);
+  cameraZoom = 1.5;
+
+  // // (remove if unnecessary)
+  // initialViewBox = new ViewBox(
+  //   new Vector2(-2, -2), // bottom-left
+  //   new Vector2(2, 2), // top-right
+  //   0.5 // margin
+  // );
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment('\\sin\\left(\\frac{1}{x}\\right)', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      legendText: 'f(x)=\\sin\\left(\\frac{1}{x}\\right)'
+    })
+  ];
+</script>
+
+<Canvas2D
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={getLegend(appletObjects)}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+>
+  <TemplateComponent objects={appletObjects} />
+</Canvas2D>

--- a/src/routes/applet/calculus/limits_at_a_point/sine_of_one_over_x/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/sine_of_one_over_x/+page.svelte
@@ -14,7 +14,6 @@
   import { getLegend } from '$lib/template/ObjectFormulas';
   import { toLatexText } from '$lib/utils/FormatString';
 
-  let initialViewBox: ViewBox | undefined;
   let cameraPosition: Vector2 | undefined;
   let cameraZoom: number | undefined;
   let xAxisLabel: string | undefined;
@@ -63,7 +62,6 @@
 </script>
 
 <Canvas2D
-  {initialViewBox}
   {cameraPosition}
   {cameraZoom}
   legendItems={getLegend(appletObjects)}

--- a/src/routes/applet/calculus/limits_at_a_point/some_function/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/some_function/+page.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
+  import {
+    AppletObject,
+    AsymptoteFragment,
+    FunctionFragment,
+    ObliqueAsymptoteFragment
+  } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import { toLatexText } from '$lib/utils/FormatString';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(3, 1);
+  cameraZoom = 1.5;
+
+  // (remove if unnecessary)
+  initialViewBox = new ViewBox(
+    new Vector2(-4, -4), // bottom-left
+    new Vector2(4, 6), // top-right
+    0.5 // margin
+  );
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment('x+2', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      legendText: 'f(x)',
+      domain: { xMax: -2 }
+    }).addIncludedPoints(new Vector2(-2, 0)),
+    new FunctionFragment('\\frac{2}{x+2}', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      domain: { xMin: -2, xMax: -1 }
+    }).addGaps(new Vector2(-1, 2)),
+    new FunctionFragment('2x^2-2', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      domain: { xMin: -1, xMax: 1 }
+    }).addIncludedPoints([new Vector2(-1, 0), new Vector2(1, 0)]),
+    new FunctionFragment('1-x', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      domain: { xMin: 1 }
+    })
+  ];
+</script>
+
+<Canvas2D
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={getLegend(appletObjects)}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+>
+  <TemplateComponent objects={appletObjects} />
+</Canvas2D>

--- a/src/routes/applet/calculus/limits_at_a_point/square_root_function/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/square_root_function/+page.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
+  import {
+    AppletObject,
+    AsymptoteFragment,
+    FunctionFragment,
+    ObliqueAsymptoteFragment
+  } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import { toLatexText } from '$lib/utils/FormatString';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(3, 1);
+  cameraZoom = 1.5;
+
+  // (remove if unnecessary)
+  initialViewBox = new ViewBox(
+    new Vector2(-1, -2), // bottom-left
+    new Vector2(8, 6), // top-right
+    0.5 // margin
+  );
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment('\\sqrt{x-3}', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      legendText: 'f(x)=\\sqrt{x-3}',
+      domain: { xMin: 3 }
+    }).addIncludedPoints([new Vector2(3, 0)])
+  ];
+</script>
+
+<Canvas2D
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={getLegend(appletObjects)}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+>
+  <TemplateComponent objects={appletObjects} />
+</Canvas2D>

--- a/src/routes/applet/calculus/limits_at_a_point/two_parabolas/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/two_parabolas/+page.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
+  import {
+    AppletObject,
+    AsymptoteFragment,
+    FunctionFragment,
+    ObliqueAsymptoteFragment
+  } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import { toLatexText } from '$lib/utils/FormatString';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(3, 1);
+  cameraZoom = 1.5;
+
+  // (remove if unnecessary)
+  initialViewBox = new ViewBox(
+    new Vector2(-4, -4), // bottom-left
+    new Vector2(4, 4), // top-right
+    0.5 // margin
+  );
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment('-x^2', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      legendText: 'f(x)=-x^2'
+    }),
+    new FunctionFragment('x^2', PrimeColor.darkGreen, {
+      isDashed: false,
+      shape: 'square',
+      legendText: 'g(x)=x^2'
+    })
+  ];
+</script>
+
+<Canvas2D
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={getLegend(appletObjects)}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+>
+  <TemplateComponent objects={appletObjects} />
+</Canvas2D>

--- a/src/routes/applet/calculus/limits_at_a_point/two_parabolas_and_an_oscillating_function/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/two_parabolas_and_an_oscillating_function/+page.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
+  import {
+    AppletObject,
+    AsymptoteFragment,
+    FunctionFragment,
+    ObliqueAsymptoteFragment
+  } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import Axis from '$lib/d3/Axis.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import { toLatexText } from '$lib/utils/FormatString';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(3, 1);
+  cameraZoom = 1.5;
+
+  // (remove if unnecessary)
+  initialViewBox = new ViewBox(
+    new Vector2(-4, -1), // bottom-left
+    new Vector2(4, 2), // top-right
+    0.5 // margin
+  );
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment('-(x/4)^2*2', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      legendText: 'f(x)=-x^2'
+    }),
+    new FunctionFragment('(x/4)^2\\sin\\left(\\frac{1}{x/4}\\right)*2', PrimeColor.raspberry, {
+      isDashed: false,
+      shape: 'square',
+      legendText: 'g(x)=x^2\\sin\\left(\\frac{1}{x}\\right)'
+    }),
+    new FunctionFragment('(x/4)^2*2', PrimeColor.darkGreen, {
+      isDashed: false,
+      shape: 'square',
+      legendText: 'h(x)=x^2'
+    })
+  ];
+</script>
+
+<Canvas2D
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={getLegend(appletObjects)}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+  axis={null}
+>
+  <TemplateComponent objects={appletObjects} />
+  <Axis scaleX={4} scaleY={2} />
+</Canvas2D>

--- a/src/routes/applet/calculus/limits_at_a_point/two_rational_functions/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/two_rational_functions/+page.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
+  import {
+    AppletObject,
+    AsymptoteFragment,
+    FunctionFragment,
+    ObliqueAsymptoteFragment
+  } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import { toLatexText } from '$lib/utils/FormatString';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(3, 1);
+  cameraZoom = 1.5;
+
+  // (remove if unnecessary)
+  initialViewBox = new ViewBox(
+    new Vector2(-3, -4), // bottom-left
+    new Vector2(5, 4), // top-right
+    0.5 // margin
+  );
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment('\\frac{x-1}{x^2-1}', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      legendText: 'f(x)=\\frac{x-1}{x^2-1}'
+    }).addGaps(new Vector2(1, 0.5)),
+    new FunctionFragment('\\frac{x}{x^2-2x+1}', PrimeColor.darkGreen, {
+      isDashed: false,
+      shape: 'square',
+      legendText: 'g(x)=\\frac{x}{x^2-2x+1}'
+    })
+  ];
+</script>
+
+<Canvas2D
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={getLegend(appletObjects)}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+>
+  <TemplateComponent objects={appletObjects} />
+</Canvas2D>

--- a/src/routes/applet/calculus/limits_at_a_point/visualisation_of_a_limit/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/visualisation_of_a_limit/+page.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
+  import {
+    AppletObject,
+    AsymptoteFragment,
+    FunctionFragment,
+    ObliqueAsymptoteFragment
+  } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import Axis from '$lib/d3/Axis.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import { toLatexText } from '$lib/utils/FormatString';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(3, 1);
+  cameraZoom = 1.5;
+
+  // (remove if unnecessary)
+  initialViewBox = new ViewBox(
+    new Vector2(-1, -1), // bottom-left
+    new Vector2(7, 3), // top-right
+    0.5 // margin
+  );
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment('(0.5x)^3+1', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'square',
+      legendText: 'f(x)'
+    }),
+    new FunctionFragment('', PrimeColor.raspberry, {
+      isDashed: false,
+      shape: 'circle'
+    }).addIncludedPoints(new Vector2(2, 2), '\\left(a,L\\right)'),
+    new AsymptoteFragment(1.7, 'vertical', PrimeColor.darkGreen),
+    new AsymptoteFragment(2.3, 'vertical', PrimeColor.darkGreen),
+    new FunctionFragment('', PrimeColor.darkGreen, {
+      isDashed: true,
+      shape: 'square',
+      legendText: 'x=a\\pm\\delta'
+    }),
+    new FunctionFragment('2-0.5', PrimeColor.orange, {
+      isDashed: true,
+      shape: 'square',
+      legendText: 'y=L\\pm\\varepsilon'
+    }),
+    new FunctionFragment('2+0.5', PrimeColor.orange, {
+      isDashed: true,
+      shape: 'square'
+    })
+  ];
+</script>
+
+<Canvas2D
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={getLegend(appletObjects)}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+  axis={null}
+>
+  <TemplateComponent objects={appletObjects} />
+  <Axis showAxisNumbers={false} />
+</Canvas2D>


### PR DESCRIPTION
This pull request introduces several new interactive Svelte applets for visualizing calculus concepts, particularly focusing on limits at a point. Each applet uses a consistent template structure and leverages reusable components for rendering mathematical functions, axes, and interactive controls. The main themes are the addition of new educational visualizations and the use of template-based code for maintainability and extensibility.

**New Applet Pages for Calculus Visualization:**

* Added a page visualizing the function `f(x) = 1/(x-1)(x-2)^2` with two vertical asymptotes at `x=1` and `x=2` using `FunctionFragment` and `AsymptoteFragment` objects. (`src/routes/applet/calculus/limits_at_a_point/a_function_with_two_vertical_asymptotes/+page.svelte`)
* Added a page for the sign function, displaying `f(x) = |x|/x` with domain splitting and discontinuity at `x=0`, using gaps to illustrate the jump. (`src/routes/applet/calculus/limits_at_a_point/sign_function/+page.svelte`)
* Added a page for the limit of the sign function near zero, with interactive sliders for ε and δ, and visualizations of the corresponding bands using `InfiniteLine2D`. (`src/routes/applet/calculus/limits_at_a_point/limit_of_sign_function_near_0/+page.svelte`)
* Added a page for the function `f(x) = x^2` near `x=2`, with an interactive ε-slider and dynamically computed δ, visualizing the ε-δ definition of limit. (`src/routes/applet/calculus/limits_at_a_point/limit_of_x_squared_near_2/+page.svelte`)
* Added a page for the piecewise function with different behaviors on either side of `x=2`, including included points and gaps to illustrate discontinuity. (`src/routes/applet/calculus/limits_at_a_point/piecewise_function/+page.svelte`)
* Added a page for rounding to integers, constructing a step function using a loop to generate function fragments for each integer segment, with included points and gaps for correct visualization. (`src/routes/applet/calculus/limits_at_a_point/rounding_to_integers/+page.svelte`)
* Added a page for the function `f(x) = 1/x^2`, visualizing its behavior near the vertical asymptote at `x=0`. (`src/routes/applet/calculus/limits_at_a_point/one_over_x_squared/+page.svelte`)
* Added a page for the function `f(x) = sin(1/x)`, illustrating its oscillatory behavior near `x=0`. (`src/routes/applet/calculus/limits_at_a_point/sine_of_one_over_x/+page.svelte`)

**Shared Implementation Details:**

* All applets use a common structure with `Canvas2D`, `TemplateComponent`, and utility imports for color, vector math, and legend generation, improving maintainability and consistency across visualizations. (All references above)
* Interactive controls (sliders) are introduced where relevant to allow dynamic exploration of limit definitions and discontinuities, enhancing the educational value of the applets. [[1]](diffhunk://#diff-a0276763a56dad2a51fbc6a325a87a1e9e2d0f42adcd2e48692b121ea621b253R1-R120) [[2]](diffhunk://#diff-4c59eaa36b63fadb094068baaf31d66b23fa4a880a7a71f690c5d94b533ff233R1-R124)

These additions significantly expand the set of visual tools available for teaching and exploring limits in calculus.