### PR TITLE
Updated template for trigonometry

### DIFF
--- a/src/lib/d3/Polygon2D.svelte
+++ b/src/lib/d3/Polygon2D.svelte
@@ -8,7 +8,7 @@
     strokeWidth?: number;
     opacity?: number;
     offset?: Vector2;
-    fillStyle?: 'full' | 'dashed';
+    fillStyle?: 'full' | 'dashed' | 'none';
   };
 
   let {
@@ -27,7 +27,9 @@
   );
 
   const patternId = $derived(`dashed-pattern-${color.replace(/[^a-zA-Z0-9]/g, '')}`);
-  const fillValue = $derived(fillStyle === 'dashed' ? `url(#${patternId})` : color);
+  const fillValue = $derived(
+    fillStyle === 'dashed' ? `url(#${patternId})` : fillStyle === 'none' ? undefined : color
+  );
 </script>
 
 <!-- @component
@@ -52,6 +54,8 @@
   fill={fillValue}
   stroke={strokeColor}
   stroke-width={strokeWidth * 0.05}
+  stroke-linejoin="round"
   {opacity}
   points={pointsJoin}
+  fill-opacity={fillStyle === 'none' ? 0 : 1.0}
 />

--- a/src/lib/d3/stories/Polygon2D.stories.svelte
+++ b/src/lib/d3/stories/Polygon2D.stories.svelte
@@ -49,6 +49,13 @@
   {template}
 />
 
+<!-- Polygon with the fill style changed -->
+<Story
+  name="Fill style"
+  args={{ points: [new Vector2(0, 0), new Vector2(1, 0), new Vector2(1, 1)], fillStyle: "dashed" }}
+  {template}
+/>
+
 <!-- Transparent polygon with only the stroke, defining a triangle, offset by a vector -->
 <Story
   name="Offset"

--- a/src/lib/d3/stories/Polygon2D.stories.svelte
+++ b/src/lib/d3/stories/Polygon2D.stories.svelte
@@ -52,7 +52,7 @@
 <!-- Polygon with the fill style changed -->
 <Story
   name="Fill style"
-  args={{ points: [new Vector2(0, 0), new Vector2(1, 0), new Vector2(1, 1)], fillStyle: "dashed" }}
+  args={{ points: [new Vector2(0, 0), new Vector2(1, 0), new Vector2(1, 1)], fillStyle: 'dashed' }}
   {template}
 />
 

--- a/src/lib/template/ObjectFormulas.ts
+++ b/src/lib/template/ObjectFormulas.ts
@@ -1,5 +1,5 @@
 import { FillType, LegendItem } from '$lib/utils/Legend';
-import { AbstractFunctionFragment, AppletObject } from './TemplateAppletObjects';
+import { AbstractFunctionFragment, AppletObject, PointObject } from './TemplateAppletObjects';
 
 export function getLegend(objects: AppletObject[]): LegendItem[] {
   const legendItems: LegendItem[] = [];
@@ -35,6 +35,10 @@ export function getLegend(objects: AppletObject[]): LegendItem[] {
         legendItems.push(
           new LegendItem(obj.pointsLegendText.gaps, obj.color, obj.shape, FillType.Border)
         );
+      }
+    } else if (obj instanceof PointObject) {
+      if (obj.legendText) {
+        legendItems.push(new LegendItem(obj.legendText, obj.color, obj.shape));
       }
     }
   }

--- a/src/lib/template/ObjectFormulas.ts
+++ b/src/lib/template/ObjectFormulas.ts
@@ -1,5 +1,5 @@
 import { FillType, LegendItem } from '$lib/utils/Legend';
-import { AbstractFunctionFragment, AppletObject, PointObject } from './TemplateAppletObjects';
+import { AbstractFunctionFragment, AppletObject, Point } from './TemplateAppletObjects';
 
 export function getLegend(objects: AppletObject[]): LegendItem[] {
   const legendItems: LegendItem[] = [];
@@ -36,7 +36,7 @@ export function getLegend(objects: AppletObject[]): LegendItem[] {
           new LegendItem(obj.pointsLegendText.gaps, obj.color, obj.shape, FillType.Border)
         );
       }
-    } else if (obj instanceof PointObject) {
+    } else if (obj instanceof Point) {
       if (obj.legendText) {
         legendItems.push(new LegendItem(obj.legendText, obj.color, obj.shape));
       }

--- a/src/lib/template/TemplateAppletObjects.ts
+++ b/src/lib/template/TemplateAppletObjects.ts
@@ -271,7 +271,7 @@ export class ObliqueAsymptoteFragment extends FunctionFragment {
   }
 }
 
-export class TextObject extends AppletObject {
+export class Text extends AppletObject {
   latex: string;
   position: Vector2;
   alignment?: {
@@ -302,7 +302,7 @@ export class TextObject extends AppletObject {
   }
 }
 
-export class AngleObject extends AppletObject {
+export class Angle extends AppletObject {
   position: Vector2;
   startAngle: number;
   endAngle: number;
@@ -355,11 +355,11 @@ export class AngleObject extends AppletObject {
       hasHead?: boolean;
       distance?: number;
     }
-  ): AngleObject {
+  ): Angle {
     const sAngle = v1.angle();
     const eAngle = v2.angle();
 
-    return new AngleObject(position, sAngle, eAngle, color, options);
+    return new Angle(position, sAngle, eAngle, color, options);
   }
 
   public isRight(): boolean {
@@ -374,7 +374,7 @@ export class AngleObject extends AppletObject {
   }
 }
 
-export class PointObject extends AppletObject {
+export class Point extends AppletObject {
   position: Vector2;
   shape?: Shape;
   latex?: string;

--- a/src/lib/template/TemplateAppletObjects.ts
+++ b/src/lib/template/TemplateAppletObjects.ts
@@ -422,7 +422,7 @@ export class LineFragment extends AppletObject {
    * @param end End point of the line
    * @param color Color of the line
    * @param options.latex Text shown next to the line
-   * @param options.latexAlign How the text next to the line shuold be aligned
+   * @param options.latexAlign How the text next to the line shuold be aligned, can overwrite auto-alignment
    * @param options.isDashed Whether the line should be dashed
    */
   constructor(
@@ -452,5 +452,51 @@ export class LineFragment extends AppletObject {
     const midY = (this.startPoint.y + this.endPoint.y) / 2;
 
     return new Vector2(midX, midY);
+  }
+}
+
+export class Circle extends AppletObject {
+  origin: Vector2;
+  radius: number;
+  isDashed?: boolean;
+
+  /**
+   * Circle template object
+   * @param origin Origin point of the circle
+   * @param radius Radius of the circle
+   * @param color Color of the circle
+   * @param isDashed Whether the circle should be dashed
+   */
+  constructor(origin: Vector2, radius: number, color: PrimeColor, isDashed?: boolean) {
+    super(color);
+
+    this.origin = origin;
+    this.radius = radius;
+    this.isDashed = isDashed;
+  }
+}
+
+export class Polygon extends AppletObject {
+  points: Vector2[];
+  fillStyle: 'full' | 'dashed' | 'none' = 'none';
+  sideLatex?: string[];
+
+  /**
+   * Polygon template object
+   * @param points Points of the polygon (clockwise or anty-clockwise)
+   * @param color Color of the polygon
+   * @param options.fillStyle Style of the fill of the polygon
+   * @param options.sideLatex List of strings to put on the polygon sides, they are auto-aligned
+   */
+  constructor(
+    points: Vector2[],
+    color: PrimeColor,
+    options?: { fillStyle?: 'full' | 'dashed' | 'none'; sideLatex?: string[] }
+  ) {
+    super(color);
+
+    this.points = points;
+    if (options?.fillStyle) this.fillStyle = options?.fillStyle;
+    this.sideLatex = options?.sideLatex;
   }
 }

--- a/src/lib/template/TemplateAppletObjects.ts
+++ b/src/lib/template/TemplateAppletObjects.ts
@@ -497,6 +497,7 @@ export class Polygon extends AppletObject {
   points: Vector2[];
   fillStyle: 'full' | 'dashed' | 'none' = 'none';
   sideLatex?: string[];
+  verticesLatex?: string[];
 
   /**
    * Polygon template object
@@ -504,16 +505,22 @@ export class Polygon extends AppletObject {
    * @param color Color of the polygon
    * @param options.fillStyle Style of the fill of the polygon
    * @param options.sideLatex List of strings to put on the polygon sides, they are auto-aligned
+   * @param options.verticesLatex List of strings to put on the vertices, they are auto-aligned
    */
   constructor(
     points: Vector2[],
     color: PrimeColor,
-    options?: { fillStyle?: 'full' | 'dashed' | 'none'; sideLatex?: string[] }
+    options?: {
+      fillStyle?: 'full' | 'dashed' | 'none';
+      sideLatex?: string[];
+      verticesLatex?: string[];
+    }
   ) {
     super(color);
 
     this.points = points;
     if (options?.fillStyle) this.fillStyle = options?.fillStyle;
     this.sideLatex = options?.sideLatex;
+    this.verticesLatex = options?.verticesLatex;
   }
 }

--- a/src/lib/template/TemplateAppletObjects.ts
+++ b/src/lib/template/TemplateAppletObjects.ts
@@ -375,3 +375,37 @@ export class AngleObject extends AppletObject {
     return [v1, v2];
   }
 }
+
+export class PointObject extends AppletObject {
+  position: Vector2;
+  color: PrimeColor;
+  shape?: Shape;
+  latex?: string;
+  legendText?: string;
+
+  /**
+   * Point template object
+   * @param position Position of the points
+   * @param color Color of the points
+   * @param options.shape Shape of the point
+   * @param options.latex Latex shown next to the point
+   * @param options.legendText Legend text of the point
+   */
+  constructor(
+    position: Vector2,
+    color: PrimeColor,
+    options?: {
+      shape?: Shape;
+      latex?: string;
+      legendText?: string;
+    }
+  ) {
+    super();
+
+    this.position = position;
+    this.color = color;
+    this.shape = options?.shape;
+    this.latex = options?.latex;
+    this.legendText = options?.legendText;
+  }
+}

--- a/src/lib/template/TemplateAppletObjects.ts
+++ b/src/lib/template/TemplateAppletObjects.ts
@@ -405,3 +405,52 @@ export class PointObject extends AppletObject {
     this.legendText = options?.legendText;
   }
 }
+
+export class LineFragment extends AppletObject {
+  startPoint: Vector2;
+  endPoint: Vector2;
+  latex?: string;
+  latexAlign?: {
+    alignX?: 'left' | 'right' | 'center' | null;
+    alignY?: 'top' | 'bottom' | 'center' | null;
+  };
+  isDashed?: boolean;
+
+  /**
+   * Line fragment template object
+   * @param start Start point of the line
+   * @param end End point of the line
+   * @param color Color of the line
+   * @param options.latex Text shown next to the line
+   * @param options.latexAlign How the text next to the line shuold be aligned
+   * @param options.isDashed Whether the line should be dashed
+   */
+  constructor(
+    start: Vector2,
+    end: Vector2,
+    color: PrimeColor,
+    options?: {
+      latex?: string;
+      isDashed?: boolean;
+      latexAlign?: {
+        alignX?: 'left' | 'right' | 'center' | null;
+        alignY?: 'top' | 'bottom' | 'center' | null;
+      };
+    }
+  ) {
+    super(color);
+
+    this.startPoint = start;
+    this.endPoint = end;
+    this.latex = options?.latex;
+    this.isDashed = options?.isDashed;
+    this.latexAlign = options?.latexAlign;
+  }
+
+  public midpoint() {
+    const midX = (this.startPoint.x + this.endPoint.x) / 2;
+    const midY = (this.startPoint.y + this.endPoint.y) / 2;
+
+    return new Vector2(midX, midY);
+  }
+}

--- a/src/lib/template/TemplateAppletObjects.ts
+++ b/src/lib/template/TemplateAppletObjects.ts
@@ -16,10 +16,15 @@ type Integral = {
 
 type Shape = 'circle' | 'square' | 'triangle';
 
-export class AppletObject {}
+export abstract class AppletObject {
+  color: PrimeColor;
+
+  constructor(color: PrimeColor) {
+    this.color = color;
+  }
+}
 
 export abstract class AbstractFunctionFragment extends AppletObject {
-  color: PrimeColor;
   domain: Domain | undefined;
   gaps: Vector2[] = [];
   includedPoints: Vector2[] = [];
@@ -51,9 +56,8 @@ export abstract class AbstractFunctionFragment extends AppletObject {
       legendText?: string;
     }
   ) {
-    super();
+    super(color);
 
-    this.color = color;
     this.domain = options?.domain;
     this.legendText = options?.legendText;
     if (options?.isDashed) this.isDashed = options.isDashed;
@@ -238,7 +242,6 @@ export class ParameterizedFunctionFragment extends AbstractFunctionFragment {
 }
 
 export class AsymptoteFragment extends AppletObject {
-  color: PrimeColor;
   position: number;
   type: 'vertical' | 'horizontal';
 
@@ -249,10 +252,9 @@ export class AsymptoteFragment extends AppletObject {
    * @param color color of the asymptote
    */
   constructor(position: number, type: 'vertical' | 'horizontal', color: PrimeColor) {
-    super();
+    super(color);
 
     this.type = type;
-    this.color = color;
     this.position = position;
   }
 }
@@ -272,7 +274,6 @@ export class ObliqueAsymptoteFragment extends FunctionFragment {
 export class TextObject extends AppletObject {
   latex: string;
   position: Vector2;
-  color: PrimeColor;
   alignment?: {
     alignX?: 'left' | 'right' | 'center' | null;
     alignY?: 'top' | 'bottom' | 'center' | null;
@@ -293,11 +294,10 @@ export class TextObject extends AppletObject {
       alignY?: 'top' | 'bottom' | 'center' | null;
     }
   ) {
-    super();
+    super(color);
 
     this.latex = latex;
     this.position = position;
-    this.color = color;
     this.alignment = alignment;
   }
 }
@@ -306,7 +306,6 @@ export class AngleObject extends AppletObject {
   position: Vector2;
   startAngle: number;
   endAngle: number;
-  color: PrimeColor;
   hasHead?: boolean;
   distance?: number;
 
@@ -329,12 +328,11 @@ export class AngleObject extends AppletObject {
       distance?: number;
     }
   ) {
-    super();
+    super(color);
 
     this.position = position;
     this.startAngle = startAngle;
     this.endAngle = endAngle;
-    this.color = color;
     this.hasHead = options?.hasHead;
     this.distance = options?.distance;
   }
@@ -378,7 +376,6 @@ export class AngleObject extends AppletObject {
 
 export class PointObject extends AppletObject {
   position: Vector2;
-  color: PrimeColor;
   shape?: Shape;
   latex?: string;
   legendText?: string;
@@ -400,10 +397,9 @@ export class PointObject extends AppletObject {
       legendText?: string;
     }
   ) {
-    super();
+    super(color);
 
     this.position = position;
-    this.color = color;
     this.shape = options?.shape;
     this.latex = options?.latex;
     this.legendText = options?.legendText;

--- a/src/lib/template/TemplateAppletObjects.ts
+++ b/src/lib/template/TemplateAppletObjects.ts
@@ -307,6 +307,8 @@ export class AngleObject extends AppletObject {
   startAngle: number;
   endAngle: number;
   color: PrimeColor;
+  hasHead?: boolean;
+  distance?: number;
 
   /**
    * Angle template object
@@ -314,14 +316,27 @@ export class AngleObject extends AppletObject {
    * @param startAngle Start angle of the angle (radians)
    * @param endAngle End angle of the angle (radians)
    * @param color Color of the angle
+   * @param options.hasHead Whether the angle shuold have an arrow head
+   * @param options.distance Distance of the angle arch from the origin
    */
-  constructor(position: Vector2, startAngle: number, endAngle: number, color: PrimeColor) {
+  constructor(
+    position: Vector2,
+    startAngle: number,
+    endAngle: number,
+    color: PrimeColor,
+    options?: {
+      hasHead?: boolean;
+      distance?: number;
+    }
+  ) {
     super();
 
     this.position = position;
     this.startAngle = startAngle;
     this.endAngle = endAngle;
     this.color = color;
+    this.hasHead = options?.hasHead;
+    this.distance = options?.distance;
   }
 
   /**
@@ -330,12 +345,23 @@ export class AngleObject extends AppletObject {
    * @param v1 First vector that describes the angle
    * @param v2 Second vector that describes the angle
    * @param color Color of the angle
+   * @param options.hasHead Whether the angle shuold have an arrow head
+   * @param options.distance Distance of the angle arch from the origin
    */
-  static fromVectors(position: Vector2, v1: Vector2, v2: Vector2, color: PrimeColor): AngleObject {
+  static fromVectors(
+    position: Vector2,
+    v1: Vector2,
+    v2: Vector2,
+    color: PrimeColor,
+    options?: {
+      hasHead?: boolean;
+      distance?: number;
+    }
+  ): AngleObject {
     const sAngle = v1.angle();
     const eAngle = v2.angle();
 
-    return new AngleObject(position, sAngle, eAngle, color);
+    return new AngleObject(position, sAngle, eAngle, color, options);
   }
 
   public isRight(): boolean {

--- a/src/lib/template/TemplateAppletObjects.ts
+++ b/src/lib/template/TemplateAppletObjects.ts
@@ -1,5 +1,5 @@
 import type { PrimeColor } from '../utils/PrimeColors';
-import type { Vector2 } from 'three';
+import { Vector2 } from 'three';
 import { parse, compile } from '@cortex-js/compute-engine';
 
 type Domain = {
@@ -299,5 +299,53 @@ export class TextObject extends AppletObject {
     this.position = position;
     this.color = color;
     this.alignment = alignment;
+  }
+}
+
+export class AngleObject extends AppletObject {
+  position: Vector2;
+  startAngle: number;
+  endAngle: number;
+  color: PrimeColor;
+
+  /**
+   * Angle template object
+   * @param position Origin position of the angle
+   * @param startAngle Start angle of the angle (radians)
+   * @param endAngle End angle of the angle (radians)
+   * @param color Color of the angle
+   */
+  constructor(position: Vector2, startAngle: number, endAngle: number, color: PrimeColor) {
+    super();
+
+    this.position = position;
+    this.startAngle = startAngle;
+    this.endAngle = endAngle;
+    this.color = color;
+  }
+
+  /**
+   * Create an angle template object from 2 vectors
+   * @param position Origin position of the angle
+   * @param v1 First vector that describes the angle
+   * @param v2 Second vector that describes the angle
+   * @param color Color of the angle
+   */
+  static fromVectors(position: Vector2, v1: Vector2, v2: Vector2, color: PrimeColor): AngleObject {
+    const sAngle = v1.angle();
+    const eAngle = v2.angle();
+
+    return new AngleObject(position, sAngle, eAngle, color);
+  }
+
+  public isRight(): boolean {
+    return Math.abs(Math.abs(this.endAngle - this.startAngle) - Math.PI / 2) < 0.0001;
+  }
+
+  public getVectors(): [Vector2, Vector2] {
+    const v1 = new Vector2(Math.cos(this.startAngle), Math.sin(this.startAngle));
+    const v2 = new Vector2(Math.cos(this.endAngle), Math.sin(this.endAngle));
+
+    return [v1, v2];
   }
 }

--- a/src/lib/template/TemplateAppletObjects.ts
+++ b/src/lib/template/TemplateAppletObjects.ts
@@ -268,3 +268,36 @@ export class ObliqueAsymptoteFragment extends FunctionFragment {
     super(func, color, { isDashed: true, legendText: legendText });
   }
 }
+
+export class TextObject extends AppletObject {
+  latex: string;
+  position: Vector2;
+  color: PrimeColor;
+  alignment?: {
+    alignX?: 'left' | 'right' | 'center' | null;
+    alignY?: 'top' | 'bottom' | 'center' | null;
+  };
+
+  /**
+   * Text template object
+   * @param latex Latex string to display
+   * @param position Position of the text in the scene
+   * @param color Color of the text
+   */
+  constructor(
+    latex: string,
+    position: Vector2,
+    color: PrimeColor,
+    alignment?: {
+      alignX?: 'left' | 'right' | 'center' | null;
+      alignY?: 'top' | 'bottom' | 'center' | null;
+    }
+  ) {
+    super();
+
+    this.latex = latex;
+    this.position = position;
+    this.color = color;
+    this.alignment = alignment;
+  }
+}

--- a/src/lib/template/TemplateAppletObjects.ts
+++ b/src/lib/template/TemplateAppletObjects.ts
@@ -308,6 +308,7 @@ export class Angle extends AppletObject {
   endAngle: number;
   hasHead?: boolean;
   distance?: number;
+  latex?: string;
 
   /**
    * Angle template object
@@ -317,6 +318,7 @@ export class Angle extends AppletObject {
    * @param color Color of the angle
    * @param options.hasHead Whether the angle shuold have an arrow head
    * @param options.distance Distance of the angle arch from the origin
+   * @param options.latex Latex shown next to the angle
    */
   constructor(
     position: Vector2,
@@ -326,6 +328,7 @@ export class Angle extends AppletObject {
     options?: {
       hasHead?: boolean;
       distance?: number;
+      latex?: string;
     }
   ) {
     super(color);
@@ -335,6 +338,7 @@ export class Angle extends AppletObject {
     this.endAngle = endAngle;
     this.hasHead = options?.hasHead;
     this.distance = options?.distance;
+    this.latex = options?.latex;
   }
 
   /**
@@ -345,6 +349,7 @@ export class Angle extends AppletObject {
    * @param color Color of the angle
    * @param options.hasHead Whether the angle shuold have an arrow head
    * @param options.distance Distance of the angle arch from the origin
+   * @param options.latex Latex shown next to the angle
    */
   static fromVectors(
     position: Vector2,
@@ -354,6 +359,7 @@ export class Angle extends AppletObject {
     options?: {
       hasHead?: boolean;
       distance?: number;
+      latex?: string;
     }
   ): Angle {
     const sAngle = v1.angle();

--- a/src/lib/template/TemplateAppletObjects.ts
+++ b/src/lib/template/TemplateAppletObjects.ts
@@ -459,20 +459,31 @@ export class Circle extends AppletObject {
   origin: Vector2;
   radius: number;
   isDashed?: boolean;
+  radiiShown?: number[];
+  radiusLatex?: string;
 
   /**
    * Circle template object
    * @param origin Origin point of the circle
    * @param radius Radius of the circle
    * @param color Color of the circle
-   * @param isDashed Whether the circle should be dashed
+   * @param options.isDashed Whether the circle should be dashed
+   * @param options.radiiShown List of angles (radians) for which radius is drawn
+   * @param options.radiusLatex Latex drawn next to radii
    */
-  constructor(origin: Vector2, radius: number, color: PrimeColor, isDashed?: boolean) {
+  constructor(
+    origin: Vector2,
+    radius: number,
+    color: PrimeColor,
+    options?: { isDashed?: boolean; radiiShown?: number[]; radiusLatex?: string }
+  ) {
     super(color);
 
     this.origin = origin;
     this.radius = radius;
-    this.isDashed = isDashed;
+    this.isDashed = options?.isDashed;
+    this.radiiShown = options?.radiiShown;
+    this.radiusLatex = options?.radiusLatex;
   }
 }
 

--- a/src/lib/template/TemplateComponent.svelte
+++ b/src/lib/template/TemplateComponent.svelte
@@ -8,11 +8,13 @@
     FunctionFragment,
     ImplicitFunctionFragment,
     ParameterizedFunctionFragment,
+    TextObject,
     type AppletObject
   } from './TemplateAppletObjects';
   import Point2D from '$lib/d3/Point2D.svelte';
   import ImplicitFunction2D from '$lib/d3/ImplicitFunction2D.svelte';
   import ParameterizedFunction2D from '$lib/d3/ParameterizedFunction2D.svelte';
+  import Latex2D from '$lib/d3/Latex2D.svelte';
 
   let { objects }: { objects: AppletObject[] } = $props();
 </script>
@@ -81,5 +83,13 @@
         isDashed={true}
       />
     {/if}
+  {:else if object instanceof TextObject}
+    <Latex2D
+      position={object.position}
+      latex={object.latex}
+      color={object.color.toString()}
+      alignX={object.alignment?.alignX}
+      alignY={object.alignment?.alignY}
+    />
   {/if}
 {/each}

--- a/src/lib/template/TemplateComponent.svelte
+++ b/src/lib/template/TemplateComponent.svelte
@@ -158,6 +158,34 @@
       color={object.color.toString()}
       isDashed={object.isDashed}
     />
+    {#each object.radiiShown as angle, i (i)}
+      {@const endPoint = object.origin
+        .clone()
+        .addScaledVector(new Vector2(Math.cos(angle), Math.sin(angle)), object.radius)}
+      <Line2D
+        start={object.origin}
+        end={endPoint}
+        color={object.color.toString()}
+        isDashed={object.isDashed}
+      />
+      {#if object.radiusLatex}
+        {@const v = endPoint.clone().add(object.origin.clone()).divideScalar(2)}
+        {@const isVertical = Math.abs(endPoint.x - object.origin.x) < 1e-6}
+        {@const alignX = Math.abs(v.x) < 1e-6 ? 'center' : v.x > 0 ? 'left' : 'right'}
+        {@const alignY = Math.abs(v.y) < 1e-6 ? 'center' : v.y > 0 ? 'bottom' : 'top'}
+        {@const offset = isVertical
+          ? new Vector2(alignX === 'right' ? -0.08 : 0.08, 0)
+          : new Vector2(0, 0)}
+        <Latex2D
+          position={v}
+          {offset}
+          latex={object.radiusLatex}
+          color={object.color.toString()}
+          {alignX}
+          {alignY}
+        />
+      {/if}
+    {/each}
   {:else if object instanceof Polygon}
     <Polygon2D
       points={object.points}

--- a/src/lib/template/TemplateComponent.svelte
+++ b/src/lib/template/TemplateComponent.svelte
@@ -100,6 +100,7 @@
         color={object.color.toString()}
         origin={object.position}
         vs={object.getVectors()}
+        size={object.distance}
       />
     {:else}
       <Angle2D
@@ -107,6 +108,8 @@
         color={object.color.toString()}
         startAngle={object.startAngle}
         endAngle={object.endAngle}
+        hasHead={object.hasHead}
+        distance={object.distance}
       />
     {/if}
   {/if}

--- a/src/lib/template/TemplateComponent.svelte
+++ b/src/lib/template/TemplateComponent.svelte
@@ -4,14 +4,14 @@
   import { Vector2 } from 'three';
   import {
     AbstractFunctionFragment,
-    AngleObject,
+    Angle,
     AsymptoteFragment,
     FunctionFragment,
     ImplicitFunctionFragment,
     LineFragment,
     ParameterizedFunctionFragment,
-    PointObject,
-    TextObject,
+    Point,
+    Text,
     type AppletObject
   } from './TemplateAppletObjects';
   import Point2D from '$lib/d3/Point2D.svelte';
@@ -89,7 +89,7 @@
         isDashed={true}
       />
     {/if}
-  {:else if object instanceof TextObject}
+  {:else if object instanceof Text}
     <Latex2D
       position={object.position}
       latex={object.latex}
@@ -97,7 +97,7 @@
       alignX={object.alignment?.alignX}
       alignY={object.alignment?.alignY}
     />
-  {:else if object instanceof AngleObject}
+  {:else if object instanceof Angle}
     {#if object.isRight()}
       <RightAngle2D
         color={object.color.toString()}
@@ -115,7 +115,7 @@
         distance={object.distance}
       />
     {/if}
-  {:else if object instanceof PointObject}
+  {:else if object instanceof Point}
     <Point2D position={object.position} color={object.color.toString()} shape={object.shape} />
     {#if object.latex}
       <Latex2D position={object.position} latex={object.latex} color={object.color.toString()} />

--- a/src/lib/template/TemplateComponent.svelte
+++ b/src/lib/template/TemplateComponent.svelte
@@ -224,5 +224,17 @@
         : new Vector2(0, 0)}
       <Latex2D {latex} position={v} {offset} color={object.color.toString()} {alignX} {alignY} />
     {/each}
+    {@const center = object.points
+      .reduce((acc, p) => acc.add(p), new Vector2(0, 0))
+      .divideScalar(object.points.length)}
+    {#each object.verticesLatex as latex, i (i)}
+      {@const v = object.points[i].clone()}
+      {@const d = v.clone().sub(center)}
+      {@const alignX = Math.abs(d.x) < 1e-6 ? 'center' : d.x > 0 ? 'left' : 'right'}
+      {@const alignY = Math.abs(d.y) < 1e-6 ? 'center' : d.y > 0 ? 'bottom' : 'top'}
+      {@const offset =
+        d.lengthSq() < 1e-12 ? new Vector2(0, 0) : d.clone().normalize().multiplyScalar(0.08)}
+      <Latex2D {latex} position={v} {offset} color={object.color.toString()} {alignX} {alignY} />
+    {/each}
   {/if}
 {/each}

--- a/src/lib/template/TemplateComponent.svelte
+++ b/src/lib/template/TemplateComponent.svelte
@@ -6,11 +6,13 @@
     AbstractFunctionFragment,
     Angle,
     AsymptoteFragment,
+    Circle,
     FunctionFragment,
     ImplicitFunctionFragment,
     LineFragment,
     ParameterizedFunctionFragment,
     Point,
+    Polygon,
     Text,
     type AppletObject
   } from './TemplateAppletObjects';
@@ -21,6 +23,8 @@
   import RightAngle2D from '$lib/d3/RightAngle2D.svelte';
   import Angle2D from '$lib/d3/Angle2D.svelte';
   import Line2D from '$lib/d3/Line2D.svelte';
+  import Circle2D from '$lib/d3/Circle2D.svelte';
+  import Polygon2D from '$lib/d3/Polygon2D.svelte';
 
   let { objects }: { objects: AppletObject[] } = $props();
 </script>
@@ -128,13 +132,49 @@
       isDashed={object.isDashed}
     />
     {#if object.latex}
+      {@const v = object.midpoint()}
+      {@const isVertical = Math.abs(object.endPoint.x - object.startPoint.x) < 1e-6}
+      {@const alignX =
+        object.latexAlign?.alignX ?? (Math.abs(v.x) < 1e-6 ? 'center' : v.x > 0 ? 'left' : 'right')}
+      {@const alignY =
+        object.latexAlign?.alignY ?? (Math.abs(v.y) < 1e-6 ? 'center' : v.y > 0 ? 'bottom' : 'top')}
+      {@const offset =
+        !object.latexAlign?.alignX && isVertical
+          ? new Vector2(alignX === 'right' ? -0.08 : 0.08, 0)
+          : new Vector2(0, 0)}
       <Latex2D
-        position={object.midpoint()}
+        position={v}
+        {offset}
         latex={object.latex}
         color={object.color.toString()}
-        alignX={object.latexAlign?.alignX}
-        alignY={object.latexAlign?.alignY}
+        {alignX}
+        {alignY}
       />
     {/if}
+  {:else if object instanceof Circle}
+    <Circle2D
+      position={object.origin}
+      radius={object.radius}
+      color={object.color.toString()}
+      isDashed={object.isDashed}
+    />
+  {:else if object instanceof Polygon}
+    <Polygon2D
+      points={object.points}
+      color={object.color.toString()}
+      fillStyle={object.fillStyle}
+    />
+    {#each object.sideLatex as latex, i (i)}
+      {@const pStart = object.points[i].clone()}
+      {@const pEnd = object.points[(i + 1) % object.points.length].clone()}
+      {@const v = pStart.add(pEnd).divideScalar(2)}
+      {@const isVertical = Math.abs(pEnd.x - pStart.x) < 1e-6}
+      {@const alignX = Math.abs(v.x) < 1e-6 ? 'center' : v.x > 0 ? 'left' : 'right'}
+      {@const alignY = Math.abs(v.y) < 1e-6 ? 'center' : v.y > 0 ? 'bottom' : 'top'}
+      {@const offset = isVertical
+        ? new Vector2(alignX === 'right' ? -0.08 : 0.08, 0)
+        : new Vector2(0, 0)}
+      <Latex2D {latex} position={v} {offset} color={object.color.toString()} {alignX} {alignY} />
+    {/each}
   {/if}
 {/each}

--- a/src/lib/template/TemplateComponent.svelte
+++ b/src/lib/template/TemplateComponent.svelte
@@ -4,6 +4,7 @@
   import { Vector2 } from 'three';
   import {
     AbstractFunctionFragment,
+    AngleObject,
     AsymptoteFragment,
     FunctionFragment,
     ImplicitFunctionFragment,
@@ -15,6 +16,8 @@
   import ImplicitFunction2D from '$lib/d3/ImplicitFunction2D.svelte';
   import ParameterizedFunction2D from '$lib/d3/ParameterizedFunction2D.svelte';
   import Latex2D from '$lib/d3/Latex2D.svelte';
+  import RightAngle2D from '$lib/d3/RightAngle2D.svelte';
+  import Angle2D from '$lib/d3/Angle2D.svelte';
 
   let { objects }: { objects: AppletObject[] } = $props();
 </script>
@@ -91,5 +94,20 @@
       alignX={object.alignment?.alignX}
       alignY={object.alignment?.alignY}
     />
+  {:else if object instanceof AngleObject}
+    {#if object.isRight()}
+      <RightAngle2D
+        color={object.color.toString()}
+        origin={object.position}
+        vs={object.getVectors()}
+      />
+    {:else}
+      <Angle2D
+        origin={object.position}
+        color={object.color.toString()}
+        startAngle={object.startAngle}
+        endAngle={object.endAngle}
+      />
+    {/if}
   {/if}
 {/each}

--- a/src/lib/template/TemplateComponent.svelte
+++ b/src/lib/template/TemplateComponent.svelte
@@ -8,6 +8,7 @@
     AsymptoteFragment,
     FunctionFragment,
     ImplicitFunctionFragment,
+    LineFragment,
     ParameterizedFunctionFragment,
     PointObject,
     TextObject,
@@ -19,6 +20,7 @@
   import Latex2D from '$lib/d3/Latex2D.svelte';
   import RightAngle2D from '$lib/d3/RightAngle2D.svelte';
   import Angle2D from '$lib/d3/Angle2D.svelte';
+  import Line2D from '$lib/d3/Line2D.svelte';
 
   let { objects }: { objects: AppletObject[] } = $props();
 </script>
@@ -117,6 +119,22 @@
     <Point2D position={object.position} color={object.color.toString()} shape={object.shape} />
     {#if object.latex}
       <Latex2D position={object.position} latex={object.latex} color={object.color.toString()} />
+    {/if}
+  {:else if object instanceof LineFragment}
+    <Line2D
+      start={object.startPoint}
+      end={object.endPoint}
+      color={object.color.toString()}
+      isDashed={object.isDashed}
+    />
+    {#if object.latex}
+      <Latex2D
+        position={object.midpoint()}
+        latex={object.latex}
+        color={object.color.toString()}
+        alignX={object.latexAlign?.alignX}
+        alignY={object.latexAlign?.alignY}
+      />
     {/if}
   {/if}
 {/each}

--- a/src/lib/template/TemplateComponent.svelte
+++ b/src/lib/template/TemplateComponent.svelte
@@ -9,6 +9,7 @@
     FunctionFragment,
     ImplicitFunctionFragment,
     ParameterizedFunctionFragment,
+    PointObject,
     TextObject,
     type AppletObject
   } from './TemplateAppletObjects';
@@ -111,6 +112,11 @@
         hasHead={object.hasHead}
         distance={object.distance}
       />
+    {/if}
+  {:else if object instanceof PointObject}
+    <Point2D position={object.position} color={object.color.toString()} shape={object.shape} />
+    {#if object.latex}
+      <Latex2D position={object.position} latex={object.latex} color={object.color.toString()} />
     {/if}
   {/if}
 {/each}

--- a/src/lib/template/TemplateComponent.svelte
+++ b/src/lib/template/TemplateComponent.svelte
@@ -119,6 +119,26 @@
         distance={object.distance}
       />
     {/if}
+
+    {#if object.latex}
+      {@const v = object.position
+        .clone()
+        .add(object.getVectors()[0].add(object.getVectors()[1]).divideScalar(5.5))}
+      {@const isVertical = Math.abs(v.x - object.position.x) < 1e-6}
+      {@const alignX = Math.abs(v.x) < 1e-6 ? 'center' : v.x > 0 ? 'left' : 'right'}
+      {@const alignY = Math.abs(v.y) < 1e-6 ? 'center' : v.y > 0 ? 'bottom' : 'top'}
+      {@const offset = isVertical
+        ? new Vector2(alignX === 'right' ? -0.08 : 0.08, 0)
+        : new Vector2(0, 0)}
+      <Latex2D
+        latex={object.latex}
+        position={v}
+        color={object.color.toString()}
+        {alignY}
+        {alignX}
+        {offset}
+      />
+    {/if}
   {:else if object instanceof Point}
     <Point2D position={object.position} color={object.color.toString()} shape={object.shape} />
     {#if object.latex}

--- a/src/routes/applet/calculus/template/template_applet/+page.svelte
+++ b/src/routes/applet/calculus/template/template_applet/+page.svelte
@@ -141,7 +141,8 @@
       radiusLatex: 'r'
     }),
     new Polygon([new Vector2(-5, 3), new Vector2(-2, 3), new Vector2(-5, 0)], PrimeColor.cyan, {
-      sideLatex: ['a', 'b', 'c']
+      sideLatex: ['a', 'b', 'c'],
+      verticesLatex: ['A', 'B', 'C']
     })
   ];
 </script>

--- a/src/routes/applet/calculus/template/template_applet/+page.svelte
+++ b/src/routes/applet/calculus/template/template_applet/+page.svelte
@@ -6,6 +6,7 @@
     AsymptoteFragment,
     FunctionFragment,
     ImplicitFunctionFragment,
+    LineFragment,
     ObliqueAsymptoteFragment,
     ParameterizedFunctionFragment,
     PointObject,
@@ -20,6 +21,7 @@
   import { toLatexText } from '$lib/utils/FormatString';
   import ParameterizedFunction2D from '$lib/d3/ParameterizedFunction2D.svelte';
   import Vector2D from '$lib/d3/Vector2D.svelte';
+  import Vector3D from '$lib/threlte/Vector3D.svelte';
 
   let initialViewBox: ViewBox | undefined;
   let cameraPosition: Vector2 | undefined;
@@ -108,7 +110,10 @@
     }),
     new AsymptoteFragment(2, 'vertical', PrimeColor.cyan),
     new AsymptoteFragment(-1.5, 'horizontal', PrimeColor.black),
-    new ObliqueAsymptoteFragment('x+2', PrimeColor.orange)
+    new ObliqueAsymptoteFragment('x+2', PrimeColor.orange),
+    new LineFragment(new Vector2(2, -3), new Vector2(5, -3), PrimeColor.raspberry, {
+      latex: 'test'
+    })
   ];
 </script>
 

--- a/src/routes/applet/calculus/template/template_applet/+page.svelte
+++ b/src/routes/applet/calculus/template/template_applet/+page.svelte
@@ -113,7 +113,11 @@
     new LineFragment(new Vector2(2, -3), new Vector2(5, -3), PrimeColor.raspberry, {
       latex: 'test'
     }),
-    new Circle(new Vector2(-5, 3), 3, PrimeColor.blue, true),
+    new Circle(new Vector2(-5, 3), 3, PrimeColor.blue, {
+      isDashed: true,
+      radiiShown: [Math.PI / 4, Math.PI / 2, (5 / 4) * Math.PI],
+      radiusLatex: 'r'
+    }),
     new Polygon([new Vector2(-5, 3), new Vector2(-2, 3), new Vector2(-5, 0)], PrimeColor.cyan, {
       sideLatex: ['a', 'b', 'c']
     })

--- a/src/routes/applet/calculus/template/template_applet/+page.svelte
+++ b/src/routes/applet/calculus/template/template_applet/+page.svelte
@@ -8,6 +8,7 @@
     ImplicitFunctionFragment,
     ObliqueAsymptoteFragment,
     ParameterizedFunctionFragment,
+    PointObject,
     TextObject
   } from '$lib/template/TemplateAppletObjects';
   import TemplateComponent from '$lib/template/TemplateComponent.svelte';
@@ -64,17 +65,16 @@
       alignX: 'center'
     }),
     AngleObject.fromVectors(
-      new Vector2(1, 1),
-      new Vector2(1, 1),
-      new Vector2(-1, 1),
-      PrimeColor.cyan
-    ),
-    AngleObject.fromVectors(
       new Vector2(6, 1),
       new Vector2(1, 1),
       new Vector2(0, 1),
       PrimeColor.raspberry
     ),
+    new PointObject(new Vector2(5, 3), PrimeColor.yellow, {
+      latex: '\\sigma',
+      legendText: '\\sigma',
+      shape: 'square'
+    }),
     new ImplicitFunctionFragment('x^2 + y^2 = 3', PrimeColor.orange, {
       domain: {
         xMin: 1,

--- a/src/routes/applet/calculus/template/template_applet/+page.svelte
+++ b/src/routes/applet/calculus/template/template_applet/+page.svelte
@@ -21,12 +21,14 @@
   import { ViewBox } from '$lib/d3/ViewBox';
   import { getLegend } from '$lib/template/ObjectFormulas';
   import { toLatexText } from '$lib/utils/FormatString';
+  import type { AxisProps } from '$lib/d3/Axis.svelte';
 
   let initialViewBox: ViewBox | undefined;
   let cameraPosition: Vector2 | undefined;
   let cameraZoom: number | undefined;
   let xAxisLabel: string | undefined;
   let yAxisLabel: string | undefined;
+  let axis: AxisProps | undefined;
 
   // ########################
   // TUTORIAL / DOCUMENTATION
@@ -49,6 +51,23 @@
     new Vector2(4, 7), // top-right
     0.5 // margin
   );
+
+  // ####
+  // AXIS
+  // ####
+  // here are the default settings for axis, you can change them
+
+  // (remove if unnecessary)
+  axis = {
+    showOrigin: true,
+    showAxisNumbers: true,
+    logarithmicX: false,
+    logarithmicY: false,
+    scaleX: 1,
+    scaleY: 1,
+    skipX: 0,
+    skipY: 0
+  };
 
   // ###########
   // AXIS LABELS
@@ -130,6 +149,7 @@
   {cameraZoom}
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+  {axis}
 >
   <TemplateComponent objects={appletObjects} />
 </Canvas2D>

--- a/src/routes/applet/calculus/template/template_applet/+page.svelte
+++ b/src/routes/applet/calculus/template/template_applet/+page.svelte
@@ -4,24 +4,23 @@
     Angle,
     AppletObject,
     AsymptoteFragment,
+    Circle,
     FunctionFragment,
     ImplicitFunctionFragment,
     LineFragment,
     ObliqueAsymptoteFragment,
     ParameterizedFunctionFragment,
     Point,
+    Polygon,
     Text
   } from '$lib/template/TemplateAppletObjects';
   import TemplateComponent from '$lib/template/TemplateComponent.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import { PrimeColor } from '$lib/utils/PrimeColors';
-  import { Color, Vector2 } from 'three';
+  import { Vector2 } from 'three';
   import { ViewBox } from '$lib/d3/ViewBox';
   import { getLegend } from '$lib/template/ObjectFormulas';
   import { toLatexText } from '$lib/utils/FormatString';
-  import ParameterizedFunction2D from '$lib/d3/ParameterizedFunction2D.svelte';
-  import Vector2D from '$lib/d3/Vector2D.svelte';
-  import Vector3D from '$lib/threlte/Vector3D.svelte';
 
   let initialViewBox: ViewBox | undefined;
   let cameraPosition: Vector2 | undefined;
@@ -113,6 +112,10 @@
     new ObliqueAsymptoteFragment('x+2', PrimeColor.orange),
     new LineFragment(new Vector2(2, -3), new Vector2(5, -3), PrimeColor.raspberry, {
       latex: 'test'
+    }),
+    new Circle(new Vector2(-5, 3), 3, PrimeColor.blue, true),
+    new Polygon([new Vector2(-5, 3), new Vector2(-2, 3), new Vector2(-5, 0)], PrimeColor.cyan, {
+      sideLatex: ['a', 'b', 'c']
     })
   ];
 </script>

--- a/src/routes/applet/calculus/template/template_applet/+page.svelte
+++ b/src/routes/applet/calculus/template/template_applet/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
   import {
-    AngleObject,
+    Angle,
     AppletObject,
     AsymptoteFragment,
     FunctionFragment,
@@ -9,8 +9,8 @@
     LineFragment,
     ObliqueAsymptoteFragment,
     ParameterizedFunctionFragment,
-    PointObject,
-    TextObject
+    Point,
+    Text
   } from '$lib/template/TemplateAppletObjects';
   import TemplateComponent from '$lib/template/TemplateComponent.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
@@ -63,16 +63,16 @@
   // APPLET OBJECTS
   // ##############
   const appletObjects: AppletObject[] = [
-    new TextObject('\\pi', new Vector2(3, 3.14), PrimeColor.orange, {
+    new Text('\\pi', new Vector2(3, 3.14), PrimeColor.orange, {
       alignX: 'center'
     }),
-    AngleObject.fromVectors(
+    Angle.fromVectors(
       new Vector2(6, 1),
       new Vector2(1, 1),
       new Vector2(0, 1),
       PrimeColor.raspberry
     ),
-    new PointObject(new Vector2(5, 3), PrimeColor.yellow, {
+    new Point(new Vector2(5, 3), PrimeColor.yellow, {
       latex: '\\sigma',
       legendText: '\\sigma',
       shape: 'square'

--- a/src/routes/applet/calculus/template/template_applet/+page.svelte
+++ b/src/routes/applet/calculus/template/template_applet/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   /* eslint-disable @typescript-eslint/no-unused-vars */ // For ease of creating the template applets
   import {
+    AngleObject,
     AppletObject,
     AsymptoteFragment,
     FunctionFragment,
@@ -12,11 +13,12 @@
   import TemplateComponent from '$lib/template/TemplateComponent.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import { PrimeColor } from '$lib/utils/PrimeColors';
-  import { Vector2 } from 'three';
+  import { Color, Vector2 } from 'three';
   import { ViewBox } from '$lib/d3/ViewBox';
   import { getLegend } from '$lib/template/ObjectFormulas';
   import { toLatexText } from '$lib/utils/FormatString';
   import ParameterizedFunction2D from '$lib/d3/ParameterizedFunction2D.svelte';
+  import Vector2D from '$lib/d3/Vector2D.svelte';
 
   let initialViewBox: ViewBox | undefined;
   let cameraPosition: Vector2 | undefined;
@@ -61,6 +63,18 @@
     new TextObject('\\pi', new Vector2(3, 3.14), PrimeColor.orange, {
       alignX: 'center'
     }),
+    AngleObject.fromVectors(
+      new Vector2(1, 1),
+      new Vector2(1, 1),
+      new Vector2(-1, 1),
+      PrimeColor.cyan
+    ),
+    AngleObject.fromVectors(
+      new Vector2(6, 1),
+      new Vector2(1, 1),
+      new Vector2(0, 1),
+      PrimeColor.raspberry
+    ),
     new ImplicitFunctionFragment('x^2 + y^2 = 3', PrimeColor.orange, {
       domain: {
         xMin: 1,

--- a/src/routes/applet/calculus/template/template_applet/+page.svelte
+++ b/src/routes/applet/calculus/template/template_applet/+page.svelte
@@ -88,7 +88,10 @@
       new Vector2(6, 1),
       new Vector2(1, 1),
       new Vector2(0, 1),
-      PrimeColor.raspberry
+      PrimeColor.raspberry,
+      {
+        latex: '\\alpha'
+      }
     ),
     new Point(new Vector2(5, 3), PrimeColor.yellow, {
       latex: '\\sigma',

--- a/src/routes/applet/calculus/template/template_applet/+page.svelte
+++ b/src/routes/applet/calculus/template/template_applet/+page.svelte
@@ -6,7 +6,8 @@
     FunctionFragment,
     ImplicitFunctionFragment,
     ObliqueAsymptoteFragment,
-    ParameterizedFunctionFragment
+    ParameterizedFunctionFragment,
+    TextObject
   } from '$lib/template/TemplateAppletObjects';
   import TemplateComponent from '$lib/template/TemplateComponent.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
@@ -57,6 +58,9 @@
   // APPLET OBJECTS
   // ##############
   const appletObjects: AppletObject[] = [
+    new TextObject('\\pi', new Vector2(3, 3.14), PrimeColor.orange, {
+      alignX: 'center'
+    }),
     new ImplicitFunctionFragment('x^2 + y^2 = 3', PrimeColor.orange, {
       domain: {
         xMin: 1,

--- a/src/routes/tutorial_template/TutorialTemplate.mdx
+++ b/src/routes/tutorial_template/TutorialTemplate.mdx
@@ -506,6 +506,7 @@ new Angle(position, startAngle, endAngle, color, options?);
 - `options` (optional):
   - `hasHead`: draw arrow head on arc
   - `distance`: distance of arc from origin
+  - `latex`: LaTeX label shown near the angle arc
 
 Alternative constructor:
 
@@ -516,7 +517,22 @@ Angle.fromVectors(position, v1, v2, color, options?)
 Example:
 
 ```ts
-new Angle(new Vector2(0, 0), 0, Math.PI / 3, PrimeColor.orange, { hasHead: true });
+new Angle(new Vector2(0, 0), 0, Math.PI / 3, PrimeColor.orange, {
+  hasHead: true,
+  latex: '\\alpha'
+});
+```
+
+Using `fromVectors` with a label:
+
+```ts
+Angle.fromVectors(
+  new Vector2(0, 0),
+  new Vector2(1, 0),
+  new Vector2(1, 1),
+  PrimeColor.blue,
+  { latex: '\\theta' }
+);
 ```
 
 ### 11) `Polygon`

--- a/src/routes/tutorial_template/TutorialTemplate.mdx
+++ b/src/routes/tutorial_template/TutorialTemplate.mdx
@@ -149,6 +149,12 @@ The `appletObjects` array can contain the following types of objects:
 - `ParameterizedFunctionFragment`: a parametric curve defined by `x(t)` and `y(t)`.
 - `AsymptoteFragment`: a vertical or horizontal dashed asymptote.
 - `ObliqueAsymptoteFragment`: an oblique asymptote (defined by JavaScript function or LaTeX string).
+- `Text`: a standalone LaTeX label.
+- `Point`: a single point with optional shape and label.
+- `LineFragment`: a finite line segment with optional label and (optional) manual label alignment.
+- `Circle`: a circle, optionally with drawn radii and radius labels.
+- `Angle`: an angle arc (or right-angle marker).
+- `Polygon`: a polygon with optional fill and side labels.
 
 ### 1) `FunctionFragment`
 
@@ -339,6 +345,163 @@ new ObliqueAsymptoteFragment('x+2', PrimeColor.orange, "asymptote");
 new ObliqueAsymptoteFragment('-x', PrimeColor.raspberry);
 ```
 
+### 6) `Text`
+
+Constructor:
+
+```ts
+new Text(latex, position, color, alignment?);
+```
+
+- `latex`: LaTeX string to display.
+- `position`: `Vector2` position.
+- `color`: one of the `PrimeColor` values.
+- `alignment` (optional): `{ alignX?: 'left' | 'right' | 'center'; alignY?: 'top' | 'bottom' | 'center' }`.
+
+Examples:
+
+```ts
+new Text('x_0', new Vector2(1.2, -0.5), PrimeColor.black);
+new Text('A', new Vector2(-2, 3), PrimeColor.blue, { alignX: 'right', alignY: 'bottom' });
+```
+
+### 7) `Point`
+
+Constructor:
+
+```ts
+new Point(position, color, options?);
+```
+
+- `position`: `Vector2` position.
+- `color`: one of the `PrimeColor` values.
+- `options` (optional):
+  - `shape`: `'circle' | 'square' | 'triangle'`
+  - `latex`: optional point label
+  - `legendText`: optional legend text
+
+Examples:
+
+```ts
+new Point(new Vector2(1, 2), PrimeColor.orange);
+new Point(new Vector2(-1, 0), PrimeColor.raspberry, { shape: 'square', latex: 'P' });
+```
+
+### 8) `LineFragment`
+
+Constructor:
+
+```ts
+new LineFragment(start, end, color, options?);
+```
+
+- `start`, `end`: `Vector2` endpoints.
+- `color`: one of the `PrimeColor` values.
+- `options` (optional):
+  - `latex`: label near the midpoint
+  - `isDashed`: dashed segment
+  - `latexAlign`: optional manual alignment override
+
+Automatic label behavior:
+
+- If `latexAlign` is not provided, alignment is chosen from the midpoint direction (left/right and top/bottom).
+- For near-vertical lines, an extra small horizontal offset is automatically added so the label does not sit on the line.
+- If you provide `latexAlign.alignX` and/or `latexAlign.alignY`, your provided values override auto-alignment for those axes.
+
+Examples:
+
+```ts
+new LineFragment(new Vector2(-2, -1), new Vector2(2, 1), PrimeColor.darkGreen, {
+  latex: 'd'
+});
+
+new LineFragment(new Vector2(1, -2), new Vector2(1, 2), PrimeColor.blue, {
+  latex: 'x=1',
+  latexAlign: { alignX: 'left', alignY: 'center' }
+});
+```
+
+### 9) `Circle`
+
+Constructor:
+
+```ts
+new Circle(origin, radius, color, options?);
+```
+
+- `origin`: `Vector2` center.
+- `radius`: radius value.
+- `color`: one of the `PrimeColor` values.
+- `options` (optional):
+  - `isDashed`: dashed circle
+  - `radiiShown`: list of angles (in radians) where radius segments are drawn
+  - `radiusLatex`: label drawn for each shown radius
+
+Example:
+
+```ts
+new Circle(new Vector2(0, 0), 2, PrimeColor.cyan, {
+  radiiShown: [0, Math.PI / 2, Math.PI],
+  radiusLatex: 'r'
+});
+```
+
+### 10) `Angle`
+
+Constructor:
+
+```ts
+new Angle(position, startAngle, endAngle, color, options?);
+```
+
+- `position`: origin point (`Vector2`).
+- `startAngle`, `endAngle`: radians.
+- `color`: one of the `PrimeColor` values.
+- `options` (optional):
+  - `hasHead`: draw arrow head on arc
+  - `distance`: distance of arc from origin
+
+Alternative constructor:
+
+```ts
+Angle.fromVectors(position, v1, v2, color, options?)
+```
+
+Example:
+
+```ts
+new Angle(new Vector2(0, 0), 0, Math.PI / 3, PrimeColor.orange, { hasHead: true });
+```
+
+### 11) `Polygon`
+
+Constructor:
+
+```ts
+new Polygon(points, color, options?);
+```
+
+- `points`: `Vector2[]` in clockwise or anti-clockwise order.
+- `color`: one of the `PrimeColor` values.
+- `options` (optional):
+  - `fillStyle`: `'full' | 'dashed' | 'none'`
+  - `sideLatex`: labels for polygon sides (in edge order)
+
+Automatic side-label behavior:
+
+- Side labels are auto-aligned from each side midpoint direction.
+- For near-vertical sides, a small horizontal offset is added automatically to avoid overlap with the side.
+
+Example:
+
+```ts
+new Polygon(
+  [new Vector2(-2, -1), new Vector2(0, 2), new Vector2(2, -1)],
+  PrimeColor.raspberry,
+  { fillStyle: 'none', sideLatex: ['a', 'b', 'c'] }
+);
+```
+
 ## Step-by-step: create an example applet
 
 In this section, we build a small applet from scratch using only `appletObjects`.
@@ -405,7 +568,7 @@ const appletObjects: AppletObject[] = [
 
 1. **Copy the template applet** and keep the structure.
 
-2. **Edit only `appletObjects`** — Add `FunctionFragment`, `ImplicitFunctionFragment`, `ParameterizedFunctionFragment`, `AsymptoteFragment`, and `ObliqueAsymptoteFragment` objects that represent your mathematical content.
+2. **Edit only `appletObjects`** — Add objects that represent your mathematical content.
 
 3. **Combine features freely** — You can mix and match:
    - Function domains (partial or full)

--- a/src/routes/tutorial_template/TutorialTemplate.mdx
+++ b/src/routes/tutorial_template/TutorialTemplate.mdx
@@ -145,6 +145,8 @@ yAxisLabel = 'f(x)';
 The `appletObjects` array can contain the following types of objects:
 
 - `FunctionFragment`: a function graph (defined by JavaScript function or LaTeX string).
+- `ImplicitFunctionFragment`: an implicit curve defined by `f(x, y) = 0` or by an equation string such as `'x^2 + y^2 = 4'`.
+- `ParameterizedFunctionFragment`: a parametric curve defined by `x(t)` and `y(t)`.
 - `AsymptoteFragment`: a vertical or horizontal dashed asymptote.
 - `ObliqueAsymptoteFragment`: an oblique asymptote (defined by JavaScript function or LaTeX string).
 
@@ -230,7 +232,76 @@ new FunctionFragment((x: number) => x ** 2 - 1, PrimeColor.orange, {
 
 Use JavaScript functions when you want logic (for example piecewise behavior), and use LaTeX strings when you want concise math notation.
 
-### 2) `AsymptoteFragment`
+### 2) `ImplicitFunctionFragment`
+
+Constructor:
+
+```ts
+new ImplicitFunctionFragment(func, color, options?)
+```
+
+- `func`: either `(x: number, y: number) => number` or a LaTeX string.
+- For LaTeX strings, you can pass either a zero-form expression (for example `'x^2 + y^2 - 4'`) or an equation (for example `'x^2 + y^2 = 4'`).
+- `color`: one of the `PrimeColor` values.
+- `options` (optional):
+  - `domain`: `{ xMin?: number; xMax?: number }`, limits x-range used during rendering.
+  - `isDashed`: `true` or (by default) `false`.
+  - `shape`: `'circle'`, `'square'` or `'triangle'`, used for legend and points.
+  - `legendText`: text to display in the legend.
+
+Examples:
+
+```ts
+// Implicit circle
+new ImplicitFunctionFragment('x^2 + y^2 = 4', PrimeColor.darkGreen, {
+  legendText: 'x^2 + y^2 = 4'
+});
+
+// Implicit hyperbola from JS function
+new ImplicitFunctionFragment((x: number, y: number) => x * x - y * y - 1, PrimeColor.blue, {
+  domain: { xMin: -3, xMax: 3 },
+  isDashed: true
+});
+```
+
+### 3) `ParameterizedFunctionFragment`
+
+Constructor:
+
+```ts
+new ParameterizedFunctionFragment(xFunc, yFunc, color, options?)
+```
+
+- `xFunc`: either `(t: number) => number` or a LaTeX string for $x(t)$.
+- `yFunc`: either `(t: number) => number` or a LaTeX string for $y(t)$.
+- `color`: one of the `PrimeColor` values.
+- `options` (optional):
+  - `tStart`: start value for parameter `t`.
+  - `tEnd`: end value for parameter `t`.
+  - `isDashed`: `true` or (by default) `false`.
+  - `shape`: `'circle'`, `'square'` or `'triangle'`.
+  - `legendText`: text to display in the legend.
+
+Examples:
+
+```ts
+// Unit circle, traversed once
+new ParameterizedFunctionFragment('cos(t)', 'sin(t)', PrimeColor.orange, {
+  tStart: 0,
+  tEnd: 2 * Math.PI,
+  legendText: 'unit circle'
+});
+
+// Spiral from JS functions
+new ParameterizedFunctionFragment(
+  (t: number) => t * Math.cos(t),
+  (t: number) => t * Math.sin(t),
+  PrimeColor.raspberry,
+  { tStart: 0, tEnd: 4 * Math.PI }
+);
+```
+
+### 4) `AsymptoteFragment`
 
 Constructor:
 
@@ -249,7 +320,7 @@ new AsymptoteFragment(1, 'vertical', PrimeColor.cyan);
 new AsymptoteFragment(-2, 'horizontal', PrimeColor.black);
 ```
 
-### 3) `ObliqueAsymptoteFragment`
+### 5) `ObliqueAsymptoteFragment`
 
 Constructor:
 
@@ -334,7 +405,7 @@ const appletObjects: AppletObject[] = [
 
 1. **Copy the template applet** and keep the structure.
 
-2. **Edit only `appletObjects`** — Add `FunctionFragment`, `AsymptoteFragment`, and `ObliqueAsymptoteFragment` objects that represent your mathematical content.
+2. **Edit only `appletObjects`** — Add `FunctionFragment`, `ImplicitFunctionFragment`, `ParameterizedFunctionFragment`, `AsymptoteFragment`, and `ObliqueAsymptoteFragment` objects that represent your mathematical content.
 
 3. **Combine features freely** — You can mix and match:
    - Function domains (partial or full)

--- a/src/routes/tutorial_template/TutorialTemplate.mdx
+++ b/src/routes/tutorial_template/TutorialTemplate.mdx
@@ -47,6 +47,23 @@ This is the complete page component for the template applet (`src/routes/applet/
     0.5 // margin
   );
 
+  // ####
+  // AXIS
+  // ####
+  // here are the default settings for axis, you can change them
+
+  // (remove if unnecessary)
+  axis = {
+    showOrigin: true,
+    showAxisNumbers: true,
+    logarithmicX: false,
+    logarithmicY: false,
+    scaleX: 1,
+    scaleY: 1,
+    skipX: 0,
+    skipY: 0
+  };
+
   // ###########
   // AXIS LABELS
   // ###########
@@ -76,6 +93,7 @@ This is the complete page component for the template applet (`src/routes/applet/
   {cameraZoom}
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+  {axis}
 >
   <TemplateComponent objects={appletObjects} />
 </Canvas2D>
@@ -124,6 +142,34 @@ cameraZoom = 1.5;
 Notes:
 
 - Those properties cannot be used together with `ViewBox`, you need to remove its definition if you want to use this method.
+
+## Optional: configure axis
+
+You can configure axis display by setting the `axis` object.
+
+```ts
+axis = {
+  showOrigin: true,
+  showAxisNumbers: true,
+  logarithmicX: false,
+  logarithmicY: false,
+  scaleX: 1,
+  scaleY: 1,
+  skipX: 0,
+  skipY: 0
+};
+```
+
+What each option does:
+
+- `showOrigin`: show or hide the origin marker.
+- `showAxisNumbers`: show or hide axis tick labels.
+- `logarithmicX`: use logarithmic scaling on x-axis.
+- `logarithmicY`: use logarithmic scaling on y-axis.
+- `scaleX`: multiply x-axis values by this factor.
+- `scaleY`: multiply y-axis values by this factor.
+- `skipX`: skip every n-th x-axis label/tick according to axis renderer settings.
+- `skipY`: skip every n-th y-axis label/tick according to axis renderer settings.
 
 ## Optional: set axis labels
 

--- a/src/routes/tutorial_template/TutorialTemplate.mdx
+++ b/src/routes/tutorial_template/TutorialTemplate.mdx
@@ -200,7 +200,7 @@ The `appletObjects` array can contain the following types of objects:
 - `LineFragment`: a finite line segment with optional label and (optional) manual label alignment.
 - `Circle`: a circle, optionally with drawn radii and radius labels.
 - `Angle`: an angle arc (or right-angle marker).
-- `Polygon`: a polygon with optional fill and side labels.
+- `Polygon`: a polygon with optional fill, side labels, and vertex labels.
 
 ### 1) `FunctionFragment`
 
@@ -548,11 +548,17 @@ new Polygon(points, color, options?);
 - `options` (optional):
   - `fillStyle`: `'full' | 'dashed' | 'none'`
   - `sideLatex`: labels for polygon sides (in edge order)
+  - `verticesLatex`: labels for polygon vertices (in point order)
 
 Automatic side-label behavior:
 
 - Side labels are auto-aligned from each side midpoint direction.
 - For near-vertical sides, a small horizontal offset is added automatically to avoid overlap with the side.
+
+Automatic vertex-label behavior:
+
+- Vertex labels are auto-aligned using the vector from polygon center to the vertex.
+- Labels are nudged slightly outward along that same center-to-vertex direction.
 
 Example:
 
@@ -560,7 +566,11 @@ Example:
 new Polygon(
   [new Vector2(-2, -1), new Vector2(0, 2), new Vector2(2, -1)],
   PrimeColor.raspberry,
-  { fillStyle: 'none', sideLatex: ['a', 'b', 'c'] }
+  {
+    fillStyle: 'none',
+    sideLatex: ['a', 'b', 'c'],
+    verticesLatex: ['A', 'B', 'C']
+  }
 );
 ```
 


### PR DESCRIPTION
Resolves #413 

Done:
- added docs for implicit, parameterized funcs
- added text template object
- added angle template object - with arrow head, distance, auto latex
- added point template object
- added line fragment template object
- added circle template object - with automatic radii
- added polygon template object - with auto side and vertex latex
- added docs for axis config
- added docs for all new template objects 