### PR TITLE
Scale text size down by default zoom

### DIFF
--- a/src/lib/d3/CanvasD3.svelte
+++ b/src/lib/d3/CanvasD3.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-  import { onDestroy, type Snippet } from 'svelte';
+  import { onDestroy, setContext, type Snippet } from 'svelte';
   import { Vector2 } from 'three';
 
   export type Canvas2DProps = {
@@ -65,10 +65,14 @@
 
   let currentCameraTransform = $state<Transform2D>();
 
+  $effect(() => {
+    setContext('is-split', isSplit);
+  });
+
   function update2DCamera(transform2d: Transform2D) {
     // Update camera
-    if (isSplit) cameraState.splitCamera2D = Camera2D.new(transform2d, enablePan);
-    else cameraState.camera2D = Camera2D.new(transform2d, enablePan);
+    if (isSplit) cameraState.splitCamera2D = Camera2D.new(transform2d, cameraZoom, enablePan);
+    else cameraState.camera2D = Camera2D.new(transform2d, cameraZoom, enablePan);
   }
 
   const debouncedUpdate2DCamera = debounce(update2DCamera, 100);
@@ -133,8 +137,8 @@
       .call(transformFn, zoomIdentity, zoomTransform(node).invert([width / 2, height / 2]));
 
     // Update camera
-    if (isSplit) cameraState.splitCamera2D = new Camera2D(0, 0, 1);
-    else cameraState.camera2D = new Camera2D(0, 0, 1);
+    if (isSplit) cameraState.splitCamera2D = new Camera2D(0, 0, 1, cameraZoom);
+    else cameraState.camera2D = new Camera2D(0, 0, 1, cameraZoom);
   }
 
   $effect(() => {

--- a/src/lib/d3/Latex2D.svelte
+++ b/src/lib/d3/Latex2D.svelte
@@ -15,6 +15,8 @@
 
 <script lang="ts">
   import Latex from '$lib/components/Latex.svelte';
+  import { cameraState } from '$lib/stores/camera.svelte';
+  import { getContext } from 'svelte';
   import { Vector2 } from 'three';
 
   let {
@@ -47,13 +49,21 @@
   });
 
   const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+  const defZoom = $derived.by(() => {
+    if (getContext('is-split')) return cameraState.splitCamera2D?.defaultZoom || 1;
+
+    return cameraState.camera2D?.defaultZoom || 1;
+  });
+
+  const scale = $derived((0.02 * fontSize) / defZoom);
 </script>
 
 <g
   class={dimOnHover ? 'latex-dim' : ''}
   transform="translate({position.x + offset.x + extendedOffset.x}, {position.y +
     offset.y +
-    extendedOffset.y}) rotate({rotation}) scale({0.02 * fontSize},{-0.02 * fontSize})"
+    extendedOffset.y}) rotate({rotation}) scale({scale},{-scale})"
 >
   <foreignObject x="0" y="0" width=".1" height=".1" class="overflow-visible">
     {#if isSafari}

--- a/src/lib/stores/camera.svelte.ts
+++ b/src/lib/stores/camera.svelte.ts
@@ -56,14 +56,15 @@ export class Camera2D {
   constructor(
     public x: number,
     public y: number,
-    public zoom: number
+    public zoom: number,
+    public defaultZoom: number
   ) {}
 
-  static new(transform: Transform2D, enablePan = false) {
+  static new(transform: Transform2D, defaultZoom: number, enablePan = false) {
     if (enablePan) {
-      return new Camera2D(transform.x, transform.y, transform.k);
+      return new Camera2D(transform.x, transform.y, transform.k, defaultZoom);
     }
-    return new Camera2D(0, 0, transform.k);
+    return new Camera2D(0, 0, transform.k, defaultZoom);
   }
 
   static toCoordinateSystem(num: number, width: number) {


### PR DESCRIPTION
What do you think @douden ?

The text is now scaled down (or up) depending on the initial camera zoom. This only works in 2D now.

Resolves #429 