### PR TITLE
Latex2d dont always scale with defZoom

### DIFF
--- a/src/lib/d3/CanvasD3.svelte
+++ b/src/lib/d3/CanvasD3.svelte
@@ -67,6 +67,7 @@
 
   // svelte-ignore state_referenced_locally
   setContext('is-split', isSplit);
+  setContext('default-zoom', cameraZoom);
 
   function update2DCamera(transform2d: Transform2D) {
     // Update camera

--- a/src/lib/d3/CanvasD3.svelte
+++ b/src/lib/d3/CanvasD3.svelte
@@ -65,9 +65,8 @@
 
   let currentCameraTransform = $state<Transform2D>();
 
-  $effect(() => {
-    setContext('is-split', isSplit);
-  });
+  // svelte-ignore state_referenced_locally
+  setContext('is-split', isSplit);
 
   function update2DCamera(transform2d: Transform2D) {
     // Update camera

--- a/src/lib/d3/Latex2D.svelte
+++ b/src/lib/d3/Latex2D.svelte
@@ -51,6 +51,9 @@
   const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
   const defZoom = $derived.by(() => {
+    const contextZoom = getContext('default-zoom') as number | undefined;
+    if (contextZoom !== undefined) return contextZoom;
+
     if (getContext('is-split')) return cameraState.splitCamera2D?.defaultZoom || 1;
 
     return cameraState.camera2D?.defaultZoom || 1;

--- a/src/lib/d3/Latex2D.svelte
+++ b/src/lib/d3/Latex2D.svelte
@@ -56,7 +56,13 @@
     return cameraState.camera2D?.defaultZoom || 1;
   });
 
-  const scale = $derived((0.02 * fontSize) / defZoom);
+  const dontScaleWithDefaultZoom = getContext('dontScaleWithDefaultZoom') === true;
+
+  const scale = $derived.by(() => {
+    if (dontScaleWithDefaultZoom) return 0.02 * fontSize;
+
+    return (0.02 * fontSize) / defZoom;
+  });
 </script>
 
 <g

--- a/src/lib/d3/stories/Latex2D.stories.svelte
+++ b/src/lib/d3/stories/Latex2D.stories.svelte
@@ -4,7 +4,15 @@
 
   const { Story } = defineMeta({
     title: '2D Components/Latex2D',
-    component: Latex2D
+    component: Latex2D,
+    parameters: {
+      docs: {
+        description: {
+          component:
+            'Latex2D is a component that is scaled down/up depending on the default zoom of the applet. This is done to ensure that the size of text is consistent across different applets on initial load. This behaviour can be disabled by setting the context `dontScaleWithDefaultZoom` to true.'
+        }
+      }
+    }
   });
 </script>
 
@@ -22,7 +30,6 @@
   </div>
 {/snippet}
 
-<!-- Dynamic snippet should be disabled for this story -->
 <Story name="With color" args={{ latex: 'E=mc^2', color: PrimeColor.raspberry }} {template} />
 
 <!-- A LaTeX text with different content defined -->
@@ -62,6 +69,21 @@
         <Latex2D latex="Text 3" alignX="right" position={new Vector2(0, 3)} />
         <Latex2D latex="Text 4" alignY="center" position={new Vector2(1, 0)} />
         <Latex2D latex="Text 5" alignY="bottom" position={new Vector2(3, 0)} />
+      </Canvas2D>
+    </div>
+  {/snippet}
+</Story>
+
+<!-- This story showcases how the latex text scales with default zoom. This behaviour can be disabled by setting the `dontScaleWithDefaultZoom` context to true. The left scene has default cameraZoom 2 and the left one has the default value 1, but the text size on both is consistent. -->
+<Story name="Scaling with default zoom">
+  {#snippet template()}
+    <div class="h-[300px] overflow-hidden rounded-lg">
+      <Canvas2D cameraZoom={2} splitCanvas2DProps={{ cameraZoom: 1 }}>
+        <Latex2D latex="Text 1" alignX="center" position={new Vector2(2, 1)} />
+
+        {#snippet splitCanvas2DChildren()}
+          <Latex2D latex="Text 2" alignX="center" position={new Vector2(2, 1)} />
+        {/snippet}
       </Canvas2D>
     </div>
   {/snippet}

--- a/src/routes/applet/appendix/complex_numbers/+page.svelte
+++ b/src/routes/applet/appendix/complex_numbers/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Controls } from '$lib/controls/Controls';
   import Angle2D from '$lib/d3/Angle2D.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';

--- a/src/routes/applet/basisdim/standardbasis/+page.svelte
+++ b/src/routes/applet/basisdim/standardbasis/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import Latex2D from '$lib/d3/Latex2D.svelte';

--- a/src/routes/applet/change_of_basis/alternative_basis/+page.svelte
+++ b/src/routes/applet/change_of_basis/alternative_basis/+page.svelte
@@ -1,4 +1,7 @@
 <script>
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import { Vector2 } from 'three';
   import TransformedAxis from './TransformedAxis.svelte';

--- a/src/routes/applet/change_of_basis/projection/+page.svelte
+++ b/src/routes/applet/change_of_basis/projection/+page.svelte
@@ -1,4 +1,7 @@
 <script>
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import Angle3D from '$lib/threlte/Angle3D.svelte';
   import Axis3D from '$lib/threlte/Axis3D.svelte';
   import Canvas3D from '$lib/threlte/Canvas3D.svelte';

--- a/src/routes/applet/complex_basics/complex_addition/+page.svelte
+++ b/src/routes/applet/complex_basics/complex_addition/+page.svelte
@@ -1,4 +1,7 @@
 <script>
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import Latex2D from '$lib/d3/Latex2D.svelte';

--- a/src/routes/applet/complex_basics/complex_inversion/+page.svelte
+++ b/src/routes/applet/complex_basics/complex_inversion/+page.svelte
@@ -1,4 +1,7 @@
 <script>
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Angle2D from '$lib/d3/Angle2D.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';

--- a/src/routes/applet/crossproduct/areatriangle/+page.svelte
+++ b/src/routes/applet/crossproduct/areatriangle/+page.svelte
@@ -1,4 +1,7 @@
 <script>
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import Axis3D from '$lib/threlte/Axis3D.svelte';
   import Canvas3D from '$lib/threlte/Canvas3D.svelte';
   import Latex3D from '$lib/threlte/Latex3D.svelte';

--- a/src/routes/applet/det_geometric/linearity_one/+page.svelte
+++ b/src/routes/applet/det_geometric/linearity_one/+page.svelte
@@ -1,4 +1,7 @@
 <script>
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import Latex2D from '$lib/d3/Latex2D.svelte';
   import Polygon2D from '$lib/d3/Polygon2D.svelte';

--- a/src/routes/applet/det_geometric/linearity_two/+page.svelte
+++ b/src/routes/applet/det_geometric/linearity_two/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import Latex2D from '$lib/d3/Latex2D.svelte';
   import Point2D from '$lib/d3/Point2D.svelte';

--- a/src/routes/applet/det_geometric/orientedarea1/+page.svelte
+++ b/src/routes/applet/det_geometric/orientedarea1/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import Arc2D from '$lib/d3/Arc2D.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';

--- a/src/routes/applet/det_geometric/paraped/+page.svelte
+++ b/src/routes/applet/det_geometric/paraped/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Angle3D from '$lib/threlte/Angle3D.svelte';

--- a/src/routes/applet/detextras/orientation/+page.svelte
+++ b/src/routes/applet/detextras/orientation/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   /* eslint-disable no-restricted-syntax */
   import { Controls } from '$lib/controls/Controls';
   import Angle2D from '$lib/d3/Angle2D.svelte';

--- a/src/routes/applet/differential/differential-equations/+page.svelte
+++ b/src/routes/applet/differential/differential-equations/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import Trajectory2D from '$lib/d3/Trajectory2D.svelte';

--- a/src/routes/applet/dot_product/CH4/+page.svelte
+++ b/src/routes/applet/dot_product/CH4/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import Axis3D from '$lib/threlte/Axis3D.svelte';
   import Canvas3D from '$lib/threlte/Canvas3D.svelte';

--- a/src/routes/applet/dot_product/angleandprojection/+page.svelte
+++ b/src/routes/applet/dot_product/angleandprojection/+page.svelte
@@ -10,6 +10,9 @@
   import { PrimeColor } from '$lib/utils/PrimeColors';
   import { Vector2 } from 'three';
 
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   const draggables = [
     new Draggable(new Vector2(-3, 4), PrimeColor.darkGreen, 'v', Draggable.snapToGrid)
   ];

--- a/src/routes/applet/dot_product/diagonal_parallelogram/+page.svelte
+++ b/src/routes/applet/dot_product/diagonal_parallelogram/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Formula } from '$lib/utils/Formulas';
   import { round, snapPointToLine } from '$lib/utils/MathLib';
   import { PrimeColor } from '$lib/utils/PrimeColors';

--- a/src/routes/applet/dot_product/inner_product_length/+page.svelte
+++ b/src/routes/applet/dot_product/inner_product_length/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Angle3D from '$lib/threlte/Angle3D.svelte';

--- a/src/routes/applet/dot_product/innerproduct_projectionvectorline/+page.svelte
+++ b/src/routes/applet/dot_product/innerproduct_projectionvectorline/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Vector2 } from 'three';
   import { PrimeColor } from '$lib/utils/PrimeColors';
   import { orthogonalProjection } from '$lib/utils/MathLib';

--- a/src/routes/applet/dot_product/perpendicularline/+page.svelte
+++ b/src/routes/applet/dot_product/perpendicularline/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';

--- a/src/routes/applet/dot_product/triangle_inequality/+page.svelte
+++ b/src/routes/applet/dot_product/triangle_inequality/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import Latex2D from '$lib/d3/Latex2D.svelte';

--- a/src/routes/applet/eigenvalue_eigenvector/no_eigenvector/+page.svelte
+++ b/src/routes/applet/eigenvalue_eigenvector/no_eigenvector/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   /* eslint-disable no-restricted-syntax */
   import { Controls } from '$lib/controls/Controls';
   import type { SlideShowSteps } from '$lib/controls/SlideShow.svelte';

--- a/src/routes/applet/geom_lin_trans/3d_proj_on_line/+page.svelte
+++ b/src/routes/applet/geom_lin_trans/3d_proj_on_line/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Angle3D from '$lib/threlte/Angle3D.svelte';

--- a/src/routes/applet/geom_lin_trans/3d_proj_on_plane/+page.svelte
+++ b/src/routes/applet/geom_lin_trans/3d_proj_on_plane/+page.svelte
@@ -1,4 +1,7 @@
 <script>
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Controls } from '$lib/controls/Controls';
   import Angle3D from '$lib/threlte/Angle3D.svelte';
   import Axis3D from '$lib/threlte/Axis3D.svelte';

--- a/src/routes/applet/geom_lin_trans/3d_refl_along_plane/+page.svelte
+++ b/src/routes/applet/geom_lin_trans/3d_refl_along_plane/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Angle3D from '$lib/threlte/Angle3D.svelte';

--- a/src/routes/applet/geom_lin_trans/proj_in_r2/+page.svelte
+++ b/src/routes/applet/geom_lin_trans/proj_in_r2/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Vector2 } from 'three';
   import { PrimeColor } from '$lib/utils/PrimeColors';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';

--- a/src/routes/applet/geom_lin_trans/reflect_in_r2/+page.svelte
+++ b/src/routes/applet/geom_lin_trans/reflect_in_r2/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';

--- a/src/routes/applet/geom_lin_trans/rotisdoublerefl/+page.svelte
+++ b/src/routes/applet/geom_lin_trans/rotisdoublerefl/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Controls } from '$lib/controls/Controls';
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Angle2D from '$lib/d3/Angle2D.svelte';

--- a/src/routes/applet/geom_lin_trans/sheartrans/+page.svelte
+++ b/src/routes/applet/geom_lin_trans/sheartrans/+page.svelte
@@ -1,4 +1,7 @@
 <script>
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Controls } from '$lib/controls/Controls';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Controls } from '$lib/controls/Controls';
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example2/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example2/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Controls } from '$lib/controls/Controls';
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example3/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex-example3/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Controls } from '$lib/controls/Controls';
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-injex/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-injex/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import Latex2D from '$lib/d3/Latex2D.svelte';

--- a/src/routes/applet/injectivity_and_surjectivity/injsurj-nonsurjex/+page.svelte
+++ b/src/routes/applet/injectivity_and_surjectivity/injsurj-nonsurjex/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';

--- a/src/routes/applet/leastsquares/bestlines_point_drag/+page.svelte
+++ b/src/routes/applet/leastsquares/bestlines_point_drag/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';

--- a/src/routes/applet/leastsquares/bestlines_split_canvas/+page.svelte
+++ b/src/routes/applet/leastsquares/bestlines_split_canvas/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';

--- a/src/routes/applet/leastsquares/leastsquares/+page.svelte
+++ b/src/routes/applet/leastsquares/leastsquares/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';

--- a/src/routes/applet/linear_combinations/linearcombinations/+page.svelte
+++ b/src/routes/applet/linear_combinations/linearcombinations/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import Latex2D from '$lib/d3/Latex2D.svelte';

--- a/src/routes/applet/linear_combinations/span_one/+page.svelte
+++ b/src/routes/applet/linear_combinations/span_one/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Axis3D from '$lib/threlte/Axis3D.svelte';

--- a/src/routes/applet/linear_combinations/span_three/+page.svelte
+++ b/src/routes/applet/linear_combinations/span_three/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Axis3D from '$lib/threlte/Axis3D.svelte';

--- a/src/routes/applet/linear_combinations/span_three_plane/+page.svelte
+++ b/src/routes/applet/linear_combinations/span_three_plane/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Axis3D from '$lib/threlte/Axis3D.svelte';

--- a/src/routes/applet/linear_combinations/span_two_line/+page.svelte
+++ b/src/routes/applet/linear_combinations/span_two_line/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Axis3D from '$lib/threlte/Axis3D.svelte';

--- a/src/routes/applet/linear_combinations/span_two_plane/+page.svelte
+++ b/src/routes/applet/linear_combinations/span_two_plane/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Axis3D from '$lib/threlte/Axis3D.svelte';

--- a/src/routes/applet/linear_independence/linind_example_in_2d/+page.svelte
+++ b/src/routes/applet/linear_independence/linind_example_in_2d/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Controls } from '$lib/controls/Controls';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';

--- a/src/routes/applet/linear_independence/linind_example_in_3d/+page.svelte
+++ b/src/routes/applet/linear_independence/linind_example_in_3d/+page.svelte
@@ -1,4 +1,7 @@
 <script>
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Controls } from '$lib/controls/Controls';
   import Axis3D from '$lib/threlte/Axis3D.svelte';
   import Canvas3D from '$lib/threlte/Canvas3D.svelte';

--- a/src/routes/applet/linear_systems/row_reduction_1/+page.svelte
+++ b/src/routes/applet/linear_systems/row_reduction_1/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { controls } from './animation';
   import RowReduction from '../Row_reduction.svelte';
 </script>

--- a/src/routes/applet/linear_systems/row_reduction_2/+page.svelte
+++ b/src/routes/applet/linear_systems/row_reduction_2/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { controls } from './animation';
   import RowReduction from '../Row_reduction.svelte';
 </script>

--- a/src/routes/applet/linear_transformation/embed_r2_r3/+page.svelte
+++ b/src/routes/applet/linear_transformation/embed_r2_r3/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';

--- a/src/routes/applet/lines_and_planes/directional_vectors_plane/+page.svelte
+++ b/src/routes/applet/lines_and_planes/directional_vectors_plane/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import Axis3D from '$lib/threlte/Axis3D.svelte';
   import Canvas3D from '$lib/threlte/Canvas3D.svelte';

--- a/src/routes/applet/lines_and_planes/disjoint_planes/+page.svelte
+++ b/src/routes/applet/lines_and_planes/disjoint_planes/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Formula, Formulas } from '$lib/utils/Formulas';
   import { PrimeColor } from '$lib/utils/PrimeColors';

--- a/src/routes/applet/lines_and_planes/normal_equation_line/+page.svelte
+++ b/src/routes/applet/lines_and_planes/normal_equation_line/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import Latex2D from '$lib/d3/Latex2D.svelte';

--- a/src/routes/applet/lines_and_planes/normal_equation_plane/+page.svelte
+++ b/src/routes/applet/lines_and_planes/normal_equation_plane/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import Angle3D from '$lib/threlte/Angle3D.svelte';
   import Axis3D from '$lib/threlte/Axis3D.svelte';

--- a/src/routes/applet/lines_and_planes/normal_equation_plane_origin/+page.svelte
+++ b/src/routes/applet/lines_and_planes/normal_equation_plane_origin/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { PrimeColor } from '$lib/utils/PrimeColors';
   import Canvas3D from '$lib/threlte/Canvas3D.svelte';

--- a/src/routes/applet/lines_and_planes/parametric_line_space/+page.svelte
+++ b/src/routes/applet/lines_and_planes/parametric_line_space/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Axis3D from '$lib/threlte/Axis3D.svelte';

--- a/src/routes/applet/lines_and_planes/parametric_vector_equation/+page.svelte
+++ b/src/routes/applet/lines_and_planes/parametric_vector_equation/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Controls } from '$lib/controls/Controls';
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';

--- a/src/routes/applet/lines_and_planes/plane_line_intersection/+page.svelte
+++ b/src/routes/applet/lines_and_planes/plane_line_intersection/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Axis3D from '$lib/threlte/Axis3D.svelte';

--- a/src/routes/applet/lines_and_planes/planes_point_intersection/+page.svelte
+++ b/src/routes/applet/lines_and_planes/planes_point_intersection/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Axis3D from '$lib/threlte/Axis3D.svelte';

--- a/src/routes/applet/lines_and_planes/two_disjoint_planes/+page.svelte
+++ b/src/routes/applet/lines_and_planes/two_disjoint_planes/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Axis3D from '$lib/threlte/Axis3D.svelte';

--- a/src/routes/applet/lines_and_planes/two_plane_line_intersection/+page.svelte
+++ b/src/routes/applet/lines_and_planes/two_plane_line_intersection/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Axis3D from '$lib/threlte/Axis3D.svelte';

--- a/src/routes/applet/lines_and_planes/two_planes_coincide/+page.svelte
+++ b/src/routes/applet/lines_and_planes/two_planes_coincide/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import Axis3D from '$lib/threlte/Axis3D.svelte';
   import Canvas3D from '$lib/threlte/Canvas3D.svelte';

--- a/src/routes/applet/lines_and_planes/vector_equation/+page.svelte
+++ b/src/routes/applet/lines_and_planes/vector_equation/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Controls } from '$lib/controls/Controls';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';

--- a/src/routes/applet/matrix_operations/nilpotent/+page.svelte
+++ b/src/routes/applet/matrix_operations/nilpotent/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Controls } from '$lib/controls/Controls';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import Point2D from '$lib/d3/Point2D.svelte';

--- a/src/routes/applet/ortho/decompas2proj/+page.svelte
+++ b/src/routes/applet/ortho/decompas2proj/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   /* eslint-disable no-restricted-syntax */
   import Canvas3D from '$lib/threlte/Canvas3D.svelte';
   import Latex3D from '$lib/threlte/Latex3D.svelte';

--- a/src/routes/applet/ortho/orthocomp/+page.svelte
+++ b/src/routes/applet/ortho/orthocomp/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import Latex2D from '$lib/d3/Latex2D.svelte';

--- a/src/routes/applet/ortho/orthodecomp/+page.svelte
+++ b/src/routes/applet/ortho/orthodecomp/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { PrimeColor } from '$lib/utils/PrimeColors';
   import Canvas3D from '$lib/threlte/Canvas3D.svelte';

--- a/src/routes/applet/solution_sets/two_lines_in_r3/+page.svelte
+++ b/src/routes/applet/solution_sets/two_lines_in_r3/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Axis3D from '$lib/threlte/Axis3D.svelte';

--- a/src/routes/applet/solution_sets/two_planes_in_r3/+page.svelte
+++ b/src/routes/applet/solution_sets/two_planes_in_r3/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import Axis3D from '$lib/threlte/Axis3D.svelte';

--- a/src/routes/applet/subspaces_in_rn/the_game/+page.svelte
+++ b/src/routes/applet/subspaces_in_rn/the_game/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Controls } from '$lib/controls/Controls';
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';

--- a/src/routes/applet/symmetric_matrices/quadratic_forms/+page.svelte
+++ b/src/routes/applet/symmetric_matrices/quadratic_forms/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import { Controls } from '$lib/controls/Controls';
   import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';

--- a/src/routes/applet/vectors/3Daddition/+page.svelte
+++ b/src/routes/applet/vectors/3Daddition/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { MathVector3 } from '$lib/utils/MathVector';
   import Axis3D from '$lib/threlte/Axis3D.svelte';
   import Canvas3D from '$lib/threlte/Canvas3D.svelte';

--- a/src/routes/applet/vectors/rules/+page.svelte
+++ b/src/routes/applet/vectors/rules/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { setContext } from 'svelte';
+  setContext('dontScaleWithDefaultZoom', true);
+
   import { Controls } from '$lib/controls/Controls';
   import { Draggable } from '$lib/controls/Draggables.svelte';
   import { Dropdown } from '$lib/controls/Dropdown.svelte';


### PR DESCRIPTION
Done:
- created a context option to ignore default zoom in scaling latex
- set the context to true in all LA applets, to mimick old behaviour
- added docs about the default zoom scaling

Script used to add the setContexts:
```python
import glob
import re
import os

files = glob.glob("src/routes/applet/*/*/+page.svelte")

count = 0
for file in files:
    # Path format: src/routes/applet/CATEGORY/APPLET/+page.svelte
    parts = file.split(os.sep)
    category = parts[3]
    
    if category in ['calculus', 'other', '[...applet]']:
        print(f"Skipping {file} (in excluded directory)")
        continue

    with open(file, 'r', encoding='utf-8') as f:
        content = f.read()

    if "dontScaleWithDefaultZoom" in content:
        print(f"Skipping {file} (already has context)")
        continue

    match = re.search(r'(<script[^>]*>)', content)
    if match:
        injection = "\n  import { setContext } from 'svelte';\n  setContext('dontScaleWithDefaultZoom', true);\n"
        
        # Check if setContext is already imported
        if "setContext" in content:
            injection = "\n  setContext('dontScaleWithDefaultZoom', true);\n"

        updated_content = content[:match.end()] + injection + content[match.end():]
        with open(file, 'w', encoding='utf-8') as f:
            f.write(updated_content)
        count += 1
        print(f"Updated {file}")
    else:
        print(f"No script tag in {file}")

print(f"Finished updating {count} files.")
```