### PR TITLE
Adjust definite-integral applets: domains, view, axes

### DIFF
--- a/src/routes/applet/calculus/definite_integrals/linear_function/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/linear_function/+page.svelte
@@ -56,12 +56,12 @@
   // APPLET OBJECTS
   // ##############
   const appletObjects: AppletObject[] = [
-    new FunctionFragment('2(x/2)+1', PrimeColor.blue, {
+    new FunctionFragment('2(x)+1', PrimeColor.blue, {
       legendText: 'f(x)=2x+1',
-      domain: { xMin: 0, xMax: 6 },
+      domain: { xMin: 0, xMax: 3 },
       integral: {
         xLeft: 0,
-        xRight: 6,
+        xRight: 3,
         legendText: '\\int_{0}^{3} f(x) dx',
         isDashed: false,
         color: PrimeColor.darkGreen,
@@ -81,5 +81,5 @@
   axis={null}
 >
   <TemplateComponent objects={appletObjects} />
-  <Axis scaleX={2} skipX={1} />
+  <Axis scaleX={1} skipX={0} />
 </Canvas2D>

--- a/src/routes/applet/calculus/definite_integrals/piecewise_function/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/piecewise_function/+page.svelte
@@ -34,15 +34,15 @@
   // choose one or none of the options below - if both are specified, view box will be used
 
   // (remove if unnecessary)
-  cameraPosition = new Vector2(3, 1);
-  cameraZoom = 1.5;
+  cameraPosition = new Vector2(-0, 1);
+  cameraZoom = 1.8;
 
-  // (remove if unnecessary)
-  initialViewBox = new ViewBox(
-    new Vector2(-4, -1), // bottom-left
-    new Vector2(4, 8), // top-right
-    0.5 // margin
-  );
+  // // (remove if unnecessary)
+  // initialViewBox = new ViewBox(
+  //   new Vector2(-5, -1), // bottom-left
+  //   new Vector2(4, 4), // top-right
+  //   0.5 // margin
+  // );
 
   // ###########
   // AXIS LABELS
@@ -52,8 +52,8 @@
   xAxisLabel = 'x';
   yAxisLabel = 'y';
 
-  let sX = 2;
-  let sY = 3;
+  let sX = 1;
+  let sY = 1;
 
   // ##############
   // APPLET OBJECTS
@@ -101,7 +101,7 @@
 </script>
 
 <Canvas2D
-  {initialViewBox}
+  // {initialViewBox}
   {cameraPosition}
   {cameraZoom}
   legendItems={getLegend(appletObjects)}
@@ -110,5 +110,5 @@
   axis={null}
 >
   <TemplateComponent objects={appletObjects} />
-  <Axis scaleX={sX} skipX={1} scaleY={sY} skipY={2} />
+  <Axis scaleX={sX} skipX={0} scaleY={sY} skipY={0} />
 </Canvas2D>

--- a/src/routes/applet/calculus/definite_integrals/piecewise_function_with_negative_and_positive_values/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/piecewise_function_with_negative_and_positive_values/+page.svelte
@@ -61,7 +61,7 @@
   const appletObjects: AppletObject[] = [
     new FunctionFragment('1', PrimeColor.blue, {
       legendText:
-        'f(x)=\\left\\{\\begin{array}{ll}1, &-2\\leq x<0\\\\2x-4, & 0\\leq x<2,\\\\-x+4, & 2\\leq x\\leq 5,\\end{array}\\right.',
+        'f(x)=\\left\\{\\begin{array}{rl}1, &-2\\leq x<0,\\\\2x-4, & \\phantom{-}0\\leq x<2,\\\\-x+4, & \\phantom{-}2\\leq x\\leq 5,\\end{array}\\right.',
       domain: { xMin: -2, xMax: 0 },
       integral: {
         xLeft: -2,


### PR DESCRIPTION
Update three definite-integral applets to fix domains, view settings, and axis scaling.

- linear_function: simplify function expression, reduce domain and integral right bound from 6 to 3, and change axis scaling (scaleX/skipX) to match the new domain.
- piecewise_function: adjust camera position and zoom, comment out the initial viewBox, set scale factors sX/sY to 1, and remove axis tick skipping so axes render at unit spacing.
- piecewise_function_with_negative_and_positive_values: improve LaTeX legend formatting (change array alignment and add spacing for positive entries) for clearer piecewise function display.

These changes improve visual consistency and correct displayed integration bounds and labels in the applets.