### PR TITLE
Propagate scale

### DIFF
--- a/src/lib/d3/Angle2D.svelte
+++ b/src/lib/d3/Angle2D.svelte
@@ -15,6 +15,7 @@
   import { PrimeColor } from '$lib/utils/PrimeColors';
   import { arc, symbol, symbolTriangle } from 'd3';
   import { Vector2 } from 'three';
+  import { getContext } from 'svelte';
 
   let {
     color = PrimeColor.black,
@@ -25,6 +26,11 @@
     distance = 0.8,
     hasHead = false
   }: Angle2DProps = $props();
+
+  const _scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const sx = _scale2D?.x ?? 1;
+  const sy = _scale2D?.y ?? 1;
+  const scaledOrigin = $derived(new Vector2(origin.x * sx, origin.y * sy));
 
   const inverted = $derived.by(() => startAngle > endAngle);
   const rotation = $derived.by(() => {
@@ -75,7 +81,7 @@
 
 -->
 
-<g transform="translate({origin.x}, {origin.y}) rotate({rotation})">
+<g transform="translate({scaledOrigin.x}, {scaledOrigin.y}) rotate({rotation})">
   <path {d} fill={color} />
 
   {#if hasHead}

--- a/src/lib/d3/Axis.svelte
+++ b/src/lib/d3/Axis.svelte
@@ -10,8 +10,6 @@
     showAxisY?: boolean;
     logarithmicX?: boolean;
     logarithmicY?: boolean;
-    scaleX?: number;
-    scaleY?: number;
     skipX?: number;
     skipY?: number;
     additionalTicksX?: number[];
@@ -24,6 +22,7 @@
   import { GRID_SIZE_2D } from '$lib/utils/AttributeDimensions';
   import { PrimeColor } from '$lib/utils/PrimeColors';
   import Latex2D from './Latex2D.svelte';
+  import { getContext } from 'svelte';
 
   let {
     length = GRID_SIZE_2D,
@@ -32,8 +31,6 @@
     showAxisNumbersY = true,
     logarithmicX = false,
     logarithmicY = false,
-    scaleX = 1,
-    scaleY = 1,
     skipX = 0,
     skipY = 0,
     showGridLinesX = true,
@@ -43,6 +40,10 @@
     additionalTicksX = [],
     additionalTicksY = []
   }: AxisProps = $props();
+
+  const scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const scaleX = scale2D?.x ?? 1;
+  const scaleY = scale2D?.y ?? 1;
 
   // Generate indeces for the grid lines from -length to length including 0
   let axisIndicesX = $derived([...Array(length + 1).keys()].flatMap((a) => [-a, a]));

--- a/src/lib/d3/Axis.svelte
+++ b/src/lib/d3/Axis.svelte
@@ -22,7 +22,7 @@
   import { GRID_SIZE_2D } from '$lib/utils/AttributeDimensions';
   import { PrimeColor } from '$lib/utils/PrimeColors';
   import Latex2D from './Latex2D.svelte';
-  import { getContext } from 'svelte';
+  import { getContext, setContext } from 'svelte';
 
   let {
     length = GRID_SIZE_2D,
@@ -44,6 +44,13 @@
   const scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
   const scaleX = scale2D?.x ?? 1;
   const scaleY = scale2D?.y ?? 1;
+
+  // Convert additionalTicks from display-space to world-space
+  const worldAdditionalTicksX = $derived(additionalTicksX.map((tick) => tick * scaleX));
+  const worldAdditionalTicksY = $derived(additionalTicksY.map((tick) => tick * scaleY));
+
+  // Set scale2D context to {x:1, y:1} to prevent double-scaling of internal labels
+  setContext('scale2D', { x: 1, y: 1 });
 
   // Generate indeces for the grid lines from -length to length including 0
   let axisIndicesX = $derived([...Array(length + 1).keys()].flatMap((a) => [-a, a]));
@@ -117,40 +124,41 @@
   {/each}
 
   {#each additionalTicksX as index, idx (idx)}
+    {@const worldIndex = worldAdditionalTicksX[idx]}
     <!-- Grid Lines -->
-    {#if index != 0 && showGridLinesX && showSkippedTick(index, skipX, additionalTicksX)}
+    {#if worldIndex != 0 && showGridLinesX && showSkippedTick(worldIndex, skipX, worldAdditionalTicksX)}
       <line
-        x1={index}
+        x1={worldIndex}
         y1={-length}
-        x2={index}
+        x2={worldIndex}
         y2={length}
         stroke={PrimeColor.black + PrimeColor.opacity(0.5)}
-        stroke-width={stokeWidth(index, logarithmicX)}
+        stroke-width={stokeWidth(worldIndex, logarithmicX)}
       />
     {/if}
-    {#if index == 0 && showAxisY}
+    {#if worldIndex == 0 && showAxisY}
       <!-- Y axis -->
       <line
-        x1={index}
+        x1={worldIndex}
         y1={-length}
-        x2={index}
+        x2={worldIndex}
         y2={length}
         stroke={PrimeColor.black + PrimeColor.opacity(0.5)}
-        stroke-width={stokeWidth(index, logarithmicX)}
+        stroke-width={stokeWidth(worldIndex, logarithmicX)}
       />
     {/if}
 
     <!-- Tick marks -->
-    {#if showSkippedTick(index, skipX, additionalTicksX)}
-      <line x1={index} y1={-0.1} x2={index} y2={0.1} stroke="black" stroke-width={0.02} />
+    {#if showSkippedTick(worldIndex, skipX, worldAdditionalTicksX)}
+      <line x1={worldIndex} y1={-0.1} x2={worldIndex} y2={0.1} stroke="black" stroke-width={0.02} />
     {/if}
 
-    {#if index != 0 && showAxisNumbersX && showSkippedTick(index, skipX, additionalTicksX)}
+    {#if worldIndex != 0 && showAxisNumbersX && showSkippedTick(worldIndex, skipX, worldAdditionalTicksX)}
       <!-- X axis number labels -->
-      {#if index <= length && index >= -length}
+      {#if worldIndex <= length && worldIndex >= -length}
         <Latex2D
-          latex={getTickText(index / scaleX, 'x')}
-          position={new Vector2(index, -0.15)}
+          latex={getTickText(index, 'x')}
+          position={new Vector2(worldIndex, -0.15)}
           alignX="center"
         />
       {/if}
@@ -200,40 +208,41 @@
   {/each}
 
   {#each additionalTicksY as index, idx (idx)}
+    {@const worldIndex = worldAdditionalTicksY[idx]}
     <!-- Grid Lines -->
-    {#if index != 0 && showGridLinesY && showSkippedTick(index, skipY, additionalTicksY)}
+    {#if worldIndex != 0 && showGridLinesY && showSkippedTick(worldIndex, skipY, worldAdditionalTicksY)}
       <line
         x1={-length}
-        y1={index}
+        y1={worldIndex}
         x2={length}
-        y2={index}
+        y2={worldIndex}
         stroke={PrimeColor.black + PrimeColor.opacity(0.5)}
-        stroke-width={stokeWidth(index, logarithmicY)}
+        stroke-width={stokeWidth(worldIndex, logarithmicY)}
       />
     {/if}
-    {#if index == 0 && showAxisX}
+    {#if worldIndex == 0 && showAxisX}
       <!-- X axis -->
       <line
         x1={-length}
-        y1={index}
+        y1={worldIndex}
         x2={length}
-        y2={index}
+        y2={worldIndex}
         stroke={PrimeColor.black + PrimeColor.opacity(0.5)}
-        stroke-width={stokeWidth(index, logarithmicY)}
+        stroke-width={stokeWidth(worldIndex, logarithmicY)}
       />
     {/if}
 
     <!-- Tick marks -->
-    {#if showSkippedTick(index, skipY, additionalTicksY)}
-      <line x1={-0.1} y1={index} x2={0.1} y2={index} stroke="black" stroke-width={0.02} />
+    {#if showSkippedTick(worldIndex, skipY, worldAdditionalTicksY)}
+      <line x1={-0.1} y1={worldIndex} x2={0.1} y2={worldIndex} stroke="black" stroke-width={0.02} />
     {/if}
 
-    {#if index != 0 && showAxisNumbersY && showSkippedTick(index, skipY, additionalTicksY)}
+    {#if worldIndex != 0 && showAxisNumbersY && showSkippedTick(worldIndex, skipY, worldAdditionalTicksY)}
       <!-- Y axis number labels -->
-      {#if index <= length && index >= -length}
+      {#if worldIndex <= length && worldIndex >= -length}
         <Latex2D
-          latex={getTickText(index / scaleY, 'y')}
-          position={new Vector2(yAxisTextX, index)}
+          latex={getTickText(index, 'y')}
+          position={new Vector2(yAxisTextX, worldIndex)}
           alignX={logarithmicY ? 'left' : 'right'}
           alignY="center"
         />

--- a/src/lib/d3/AxisLabels.ts
+++ b/src/lib/d3/AxisLabels.ts
@@ -43,10 +43,11 @@ export function getXLabelX(
   cameraTransform: Transform2D | undefined,
   width: number,
   cameraZoom: number,
-  labels: LabelProps | undefined
+  labels: LabelProps | undefined,
+  scaleX: number = 1
 ): number {
   const normalizedCamera = revertCameraBaseline(cameraTransform);
-  if (!cameraTransform || !normalizedCamera) return 6.8;
+  if (!cameraTransform || !normalizedCamera) return 6.8 / scaleX;
 
   const baselineX = cameraBaselineX ?? 0;
   const normalizedPanX = normalizedCamera.x;
@@ -56,7 +57,7 @@ export function getXLabelX(
   const worldXAtCenter = baselineX - 7.5 / cameraZoom + (7.5 + normalizedPanX) / totalZoom;
 
   if (labels && labels.xLabelPosition == 'center') {
-    return clamp(worldXAtCenter, -GRID_SIZE_2D, GRID_SIZE_2D);
+    return clamp(worldXAtCenter, -GRID_SIZE_2D, GRID_SIZE_2D) / scaleX;
   }
 
   const edgeMarginPx = 48;
@@ -66,7 +67,7 @@ export function getXLabelX(
   const worldPostAtRight =
     baselineX - 7.5 / cameraZoom + (rightEdgeFactor + normalizedPanX) / totalZoom;
 
-  return clamp(worldPostAtRight, -GRID_SIZE_2D, GRID_SIZE_2D);
+  return clamp(worldPostAtRight, -GRID_SIZE_2D, GRID_SIZE_2D) / scaleX;
 }
 
 export function getYabelY(
@@ -74,10 +75,11 @@ export function getYabelY(
   width: number,
   height: number,
   cameraZoom: number,
-  labels: LabelProps | undefined
+  labels: LabelProps | undefined,
+  scaleY: number = 1
 ): number {
   const normalizedCamera = revertCameraBaseline(cameraTransform);
-  if (!cameraTransform || !normalizedCamera) return 6.25;
+  if (!cameraTransform || !normalizedCamera) return 6.25 / scaleY;
 
   const baselineY = cameraBaselineY ?? 0;
   const normalizedPanY = normalizedCamera.y;
@@ -90,7 +92,7 @@ export function getYabelY(
     baselineY + scaleFactor * (height / 2 + translateY / zoom - height / (2 * zoom));
 
   if (labels && labels.yLabelPosition == 'center') {
-    return clamp(worldYAtCenter, -GRID_SIZE_2D, GRID_SIZE_2D);
+    return clamp(worldYAtCenter, -GRID_SIZE_2D, GRID_SIZE_2D) / scaleY;
   }
 
   const edgeMarginPx = 30;
@@ -98,5 +100,5 @@ export function getYabelY(
   const worldYAtTopMargin =
     baselineY + scaleFactor * (height / 2 + translateY / zoom - edgeMarginPx / zoom);
 
-  return clamp(worldYAtTopMargin, -GRID_SIZE_2D, GRID_SIZE_2D);
+  return clamp(worldYAtTopMargin, -GRID_SIZE_2D, GRID_SIZE_2D) / scaleY;
 }

--- a/src/lib/d3/Canvas2D.svelte
+++ b/src/lib/d3/Canvas2D.svelte
@@ -36,7 +36,9 @@
     enablePan = true,
     draggables = [],
     defaultLeftDivision,
-    legendFormulaPosition = 'top-right'
+    legendFormulaPosition = 'top-right',
+    scaleX = 1,
+    scaleY = 1
   }: CanvasProps = $props();
 
   const hasSplitCanvas = $derived(
@@ -141,6 +143,8 @@
       {labels}
       {enablePan}
       {draggables}
+      {scaleX}
+      {scaleY}
     >
       {@render children()}
     </CanvasD3>

--- a/src/lib/d3/CanvasD3.svelte
+++ b/src/lib/d3/CanvasD3.svelte
@@ -175,7 +175,9 @@
   });
 
   const xLabelX = $derived(getXLabelX(currentCameraTransform, width, cameraZoom, labels, scaleX));
-  const yLabelY = $derived(getYabelY(currentCameraTransform, width, height, cameraZoom, labels, scaleY));
+  const yLabelY = $derived(
+    getYabelY(currentCameraTransform, width, height, cameraZoom, labels, scaleY)
+  );
 </script>
 
 <div class="relative overflow-hidden">
@@ -221,7 +223,9 @@
                 latex={labels.yLabel}
                 fontSize={labels.size || 1}
                 position={new Vector2(
-                  0.25 / scaleX + (labels.yLabelRotate ? 0.5 / scaleX : 0) + (labels?.yLabelOffset?.x ?? 0),
+                  0.25 / scaleX +
+                    (labels.yLabelRotate ? 0.5 / scaleX : 0) +
+                    (labels?.yLabelOffset?.x ?? 0),
                   yLabelY + +(labels?.yLabelOffset?.y ?? 0)
                 )}
                 rotation={labels.yLabelRotate ? -90 : 0}

--- a/src/lib/d3/CanvasD3.svelte
+++ b/src/lib/d3/CanvasD3.svelte
@@ -13,6 +13,8 @@
     enablePan?: boolean;
     draggables?: Draggable[];
     isSplit?: boolean;
+    scaleX?: number;
+    scaleY?: number;
     children: Snippet;
   };
 </script>
@@ -53,6 +55,8 @@
     isSplit = false,
     axis,
     labels,
+    scaleX = 1,
+    scaleY = 1,
     children
   }: Canvas2DProps = $props();
 
@@ -68,6 +72,8 @@
   // svelte-ignore state_referenced_locally
   setContext('is-split', isSplit);
   setContext('default-zoom', cameraZoom);
+  // svelte-ignore state_referenced_locally
+  setContext('scale2D', { x: scaleX, y: scaleY });
 
   function update2DCamera(transform2d: Transform2D) {
     // Update camera

--- a/src/lib/d3/CanvasD3.svelte
+++ b/src/lib/d3/CanvasD3.svelte
@@ -174,8 +174,8 @@
     else cameraState.camera2D = undefined;
   });
 
-  const xLabelX = $derived(getXLabelX(currentCameraTransform, width, cameraZoom, labels));
-  const yLabelY = $derived(getYabelY(currentCameraTransform, width, height, cameraZoom, labels));
+  const xLabelX = $derived(getXLabelX(currentCameraTransform, width, cameraZoom, labels, scaleX));
+  const yLabelY = $derived(getYabelY(currentCameraTransform, width, height, cameraZoom, labels, scaleY));
 </script>
 
 <div class="relative overflow-hidden">
@@ -210,7 +210,7 @@
                 fontSize={labels.size || 1}
                 position={new Vector2(
                   xLabelX + (labels?.xLabelOffset?.x ?? 0),
-                  0.75 + (labels?.xLabelOffset?.y ?? 0)
+                  0.75 / scaleY + (labels?.xLabelOffset?.y ?? 0)
                 )}
                 alignX={labels.xLabelPosition == 'center' ? 'center' : 'right'}
               />
@@ -221,7 +221,7 @@
                 latex={labels.yLabel}
                 fontSize={labels.size || 1}
                 position={new Vector2(
-                  0.25 + (labels.yLabelRotate ? 0.5 : 0) + (labels?.yLabelOffset?.x ?? 0),
+                  0.25 / scaleX + (labels.yLabelRotate ? 0.5 / scaleX : 0) + (labels?.yLabelOffset?.x ?? 0),
                   yLabelY + +(labels?.yLabelOffset?.y ?? 0)
                 )}
                 rotation={labels.yLabelRotate ? -90 : 0}

--- a/src/lib/d3/Circle2D.svelte
+++ b/src/lib/d3/Circle2D.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { LINE_WIDTH } from '$lib/utils/AttributeDimensions';
   import { Vector2 } from 'three';
+  import { getContext } from 'svelte';
 
   export type Circle2DProps = {
     position?: Vector2;
@@ -19,6 +20,10 @@
     isDashed = false,
     fill = 'none'
   }: Circle2DProps = $props();
+
+  const _scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const sx = _scale2D?.x ?? 1;
+  const sy = _scale2D?.y ?? 1;
 </script>
 
 <!-- @component
@@ -35,12 +40,25 @@
 
 -->
 
-<circle
-  cx={position.x}
-  cy={position.y}
-  r={radius}
-  {fill}
-  stroke={color}
-  stroke-width={width}
-  stroke-dasharray={isDashed ? `${4 * width} ${4 * width}` : undefined}
-/>
+{#if sx === sy}
+  <circle
+    cx={position.x * sx}
+    cy={position.y * sy}
+    r={radius * sx}
+    {fill}
+    stroke={color}
+    stroke-width={width}
+    stroke-dasharray={isDashed ? `${4 * width} ${4 * width}` : undefined}
+  />
+{:else}
+  <ellipse
+    cx={position.x * sx}
+    cy={position.y * sy}
+    rx={radius * sx}
+    ry={radius * sy}
+    {fill}
+    stroke={color}
+    stroke-width={width}
+    stroke-dasharray={isDashed ? `${4 * width} ${4 * width}` : undefined}
+  />
+{/if}

--- a/src/lib/d3/ExplicitFunction2D.svelte
+++ b/src/lib/d3/ExplicitFunction2D.svelte
@@ -4,6 +4,7 @@
   import { Vector2 } from 'three';
   import Triangle2D from './Triangle2D.svelte';
   import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { getContext, setContext } from 'svelte';
 
   export type ExplicitFunction2DProps = {
     func: (x: number) => number;
@@ -47,6 +48,12 @@
     verticalLimit = GRID_SIZE_2D
   }: ExplicitFunction2DProps = $props();
 
+  const _scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const sx = _scale2D?.x ?? 1;
+  const sy = _scale2D?.y ?? 1;
+  // Prevent Triangle2D children (arrow heads) from applying scale to visual-space coords
+  setContext('scale2D', { x: 1, y: 1 });
+
   // Generate points for the function
   const functionRoots = $derived.by(() => {
     const segments: Vector2[][] = [];
@@ -61,7 +68,7 @@
 
     const safeVal = (x: number) => {
       try {
-        return func(x);
+        return func(x / sx) * sy;
       } catch {
         return NaN;
       }
@@ -83,7 +90,7 @@
         const xm = (x0 + x1) / 2;
         let ym: number;
         try {
-          ym = func(xm);
+          ym = func(xm / sx) * sy;
         } catch {
           ym = NaN;
         }
@@ -116,7 +123,7 @@
       return false;
     };
 
-    let prevX = xMin;
+    let prevX = xMin * sx;
     let prevY: number | null = null;
 
     const firstY = (() => {
@@ -129,7 +136,7 @@
       currentSegment.push(new Vector2(prevX, prevY));
     }
 
-    for (let x = xMin + stepSize; x <= xMax + 1e-9; x += stepSize) {
+    for (let x = xMin * sx + stepSize; x <= xMax * sx + 1e-9; x += stepSize) {
       const y = safeVal(x);
 
       if (!isFinite(y)) {
@@ -184,13 +191,14 @@
   const integralPath = $derived.by(() => {
     if (!integral) return null;
 
-    const { xLeft, xRight } = integral;
+    const xLeft = integral.xLeft * sx;
+    const xRight = integral.xRight * sx;
     const segments: Vector2[][] = [];
     let current: Vector2[] = [];
 
     const safeVal = (x: number) => {
       try {
-        return func(x);
+        return func(x / sx) * sy;
       } catch {
         return NaN;
       }

--- a/src/lib/d3/ImplicitFunction2D.svelte
+++ b/src/lib/d3/ImplicitFunction2D.svelte
@@ -2,6 +2,7 @@
   import { GRID_SIZE_2D, LINE_WIDTH } from '$lib/utils/AttributeDimensions';
   import { curveCardinal, line } from 'd3';
   import { Vector2 } from 'three';
+  import { getContext, setContext } from 'svelte';
 
   export type ImplicitFunction2DProps = {
     // function as equal to 0, e.g. "x^2 + y^2 = 1" should be passed as x^2 + y^2 - 1
@@ -107,6 +108,16 @@
     isDashed = false
   }: ImplicitFunction2DProps = $props();
 
+  const _scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const sx = _scale2D?.x ?? 1;
+  const sy = _scale2D?.y ?? 1;
+  setContext('scale2D', { x: 1, y: 1 });
+
+  const worldXMin = $derived(xMin * sx);
+  const worldXMax = $derived(xMax * sx);
+  const worldYMin = $derived(yMin * sy);
+  const worldYMax = $derived(yMax * sy);
+
   function interpolate(p1: Vector2, p2: Vector2, v1: number, v2: number): Vector2 {
     if (Math.abs(v1 - v2) < 1e-10) return p1.clone();
     const t = -v1 / (v2 - v1);
@@ -117,17 +128,17 @@
   const contourLines = $derived.by(() => {
     const lines: StartEndLine[] = [];
 
-    const gridWidth = Math.ceil((xMax - xMin) / stepSize);
-    const gridHeight = Math.ceil((yMax - yMin) / stepSize);
+    const gridWidth = Math.ceil((worldXMax - worldXMin) / stepSize);
+    const gridHeight = Math.ceil((worldYMax - worldYMin) / stepSize);
 
     const values: number[][] = [];
     for (let i = 0; i <= gridWidth; i++) {
       values[i] = [];
       for (let j = 0; j <= gridHeight; j++) {
-        const x = xMin + i * stepSize;
-        const y = yMin + j * stepSize;
+        const x = worldXMin + i * stepSize;
+        const y = worldYMin + j * stepSize;
         try {
-          const val = zeroFunc(x, y);
+          const val = zeroFunc(x / sx, y / sy);
           values[i][j] = isFinite(val) ? val : 0;
         } catch {
           values[i][j] = 0;
@@ -137,8 +148,8 @@
 
     for (let i = 0; i < gridWidth; i++) {
       for (let j = 0; j < gridHeight; j++) {
-        const x = xMin + i * stepSize;
-        const y = yMin + j * stepSize;
+        const x = worldXMin + i * stepSize;
+        const y = worldYMin + j * stepSize;
 
         // Get the four corner values
         const v00 = values[i][j];

--- a/src/lib/d3/InfiniteLine2D.svelte
+++ b/src/lib/d3/InfiniteLine2D.svelte
@@ -26,7 +26,7 @@
   const sy = _scale2D?.y ?? 1;
   const scaledOrigin = $derived(new Vector2(origin.x * sx, origin.y * sy));
 
-  const dir = $derived(direction.clone().normalize());
+  const dir = $derived(new Vector2(direction.x * sx, direction.y * sy).normalize());
   const start = $derived(dir.clone().multiplyScalar(GRID_SIZE_2D).add(scaledOrigin));
   const end = $derived(
     dir

--- a/src/lib/d3/InfiniteLine2D.svelte
+++ b/src/lib/d3/InfiniteLine2D.svelte
@@ -11,6 +11,7 @@
 <script lang="ts">
   import { GRID_SIZE_2D, LINE_WIDTH } from '$lib/utils/AttributeDimensions';
   import { Vector2 } from 'three';
+  import { getContext } from 'svelte';
 
   let {
     origin = new Vector2(0, 0),
@@ -20,13 +21,18 @@
     isDashed = false
   }: InfiniteLine2DProps = $props();
 
+  const _scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const sx = _scale2D?.x ?? 1;
+  const sy = _scale2D?.y ?? 1;
+  const scaledOrigin = $derived(new Vector2(origin.x * sx, origin.y * sy));
+
   const dir = $derived(direction.clone().normalize());
-  const start = $derived(dir.clone().multiplyScalar(GRID_SIZE_2D).add(origin));
+  const start = $derived(dir.clone().multiplyScalar(GRID_SIZE_2D).add(scaledOrigin));
   const end = $derived(
     dir
       .clone()
       .multiplyScalar(GRID_SIZE_2D * -1)
-      .add(origin)
+      .add(scaledOrigin)
   );
 </script>
 

--- a/src/lib/d3/Latex2D.svelte
+++ b/src/lib/d3/Latex2D.svelte
@@ -16,7 +16,7 @@
 <script lang="ts">
   import Latex from '$lib/components/Latex.svelte';
   import { cameraState } from '$lib/stores/camera.svelte';
-  import { getContext } from 'svelte';
+  import { getContext, setContext } from 'svelte';
   import { Vector2 } from 'three';
 
   let {
@@ -32,7 +32,15 @@
     dimOnHover = false
   }: Latex2DProps = $props();
 
-  let extendedOffset = $derived(position.clone().normalize().multiplyScalar(extend));
+  const scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const scaleX = scale2D?.x ?? 1;
+  const scaleY = scale2D?.y ?? 1;
+
+  const scaledPosition = $derived(
+    new Vector2(position.x * scaleX, position.y * scaleY)
+  );
+
+  let extendedOffset = $derived(scaledPosition.clone().normalize().multiplyScalar(extend));
 
   let style = $derived.by(() => {
     const base = 'display: inline-block; width: max-content;';
@@ -70,7 +78,7 @@
 
 <g
   class={dimOnHover ? 'latex-dim' : ''}
-  transform="translate({position.x + offset.x + extendedOffset.x}, {position.y +
+  transform="translate({scaledPosition.x + offset.x + extendedOffset.x}, {scaledPosition.y +
     offset.y +
     extendedOffset.y}) rotate({rotation}) scale({scale},{-scale})"
 >

--- a/src/lib/d3/Latex2D.svelte
+++ b/src/lib/d3/Latex2D.svelte
@@ -16,7 +16,7 @@
 <script lang="ts">
   import Latex from '$lib/components/Latex.svelte';
   import { cameraState } from '$lib/stores/camera.svelte';
-  import { getContext, setContext } from 'svelte';
+  import { getContext } from 'svelte';
   import { Vector2 } from 'three';
 
   let {
@@ -36,9 +36,7 @@
   const scaleX = scale2D?.x ?? 1;
   const scaleY = scale2D?.y ?? 1;
 
-  const scaledPosition = $derived(
-    new Vector2(position.x * scaleX, position.y * scaleY)
-  );
+  const scaledPosition = $derived(new Vector2(position.x * scaleX, position.y * scaleY));
 
   let extendedOffset = $derived(scaledPosition.clone().normalize().multiplyScalar(extend));
 

--- a/src/lib/d3/Line2D.svelte
+++ b/src/lib/d3/Line2D.svelte
@@ -11,8 +11,13 @@
 <script lang="ts">
   import { LINE_WIDTH } from '$lib/utils/AttributeDimensions';
   import { Vector2 } from 'three';
+  import { getContext } from 'svelte';
 
   let { start, end, color = 'black', width = LINE_WIDTH, isDashed = false }: Line2DProps = $props();
+
+  const _scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const sx = _scale2D?.x ?? 1;
+  const sy = _scale2D?.y ?? 1;
 </script>
 
 <!-- @component
@@ -29,10 +34,10 @@
 -->
 
 <line
-  x1={start.x}
-  y1={start.y}
-  x2={end.x}
-  y2={end.y}
+  x1={start.x * sx}
+  y1={start.y * sy}
+  x2={end.x * sx}
+  y2={end.y * sy}
   stroke={color}
   stroke-width={width}
   stroke-dasharray={isDashed ? `${4 * width} ${4 * width}` : undefined}

--- a/src/lib/d3/ParameterizedFunction2D.svelte
+++ b/src/lib/d3/ParameterizedFunction2D.svelte
@@ -3,6 +3,7 @@
   import { curveCardinal, line } from 'd3';
   import { Vector2 } from 'three';
   import Triangle2D from './Triangle2D.svelte';
+  import { getContext, setContext } from 'svelte';
 
   export type ParameterizedFunction2DProps = {
     xFunc: (t: number) => number;
@@ -30,6 +31,12 @@
     isDashed = false
   }: ParameterizedFunction2DProps = $props();
 
+  const _scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const sx = _scale2D?.x ?? 1;
+  const sy = _scale2D?.y ?? 1;
+  // Prevent Triangle2D children (arrow heads) from applying scale to visual-space coords
+  setContext('scale2D', { x: 1, y: 1 });
+
   // Generate points for the function
   const functionRoots = $derived.by(() => {
     const points: Vector2[] = [];
@@ -38,8 +45,8 @@
       let y: number;
 
       try {
-        x = xFunc(t);
-        y = yFunc(t);
+        x = xFunc(t) * sx;
+        y = yFunc(t) * sy;
         if (!isFinite(x)) continue;
         if (!isFinite(y)) continue;
       } catch {

--- a/src/lib/d3/Point2D.svelte
+++ b/src/lib/d3/Point2D.svelte
@@ -19,6 +19,7 @@
   import { Vector2 } from 'three';
   import Latex2D from './Latex2D.svelte';
   import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { getContext } from 'svelte';
 
   let {
     position = new Vector2(0, 0),
@@ -33,13 +34,18 @@
     offset = new Vector2(0, 0),
     showTextOnlyOnHover = false
   }: Point2DProps = $props();
+
+  const _scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const sx = _scale2D?.x ?? 1;
+  const sy = _scale2D?.y ?? 1;
+  const scaledPos = $derived(new Vector2(position.x * sx, position.y * sy));
 </script>
 
 <g class="point2d" {opacity}>
   {#if shape == 'square'}
     <rect
-      x={position.x - radius}
-      y={position.y - radius}
+      x={scaledPos.x - radius}
+      y={scaledPos.y - radius}
       height={radius * 2}
       width={radius * 2}
       stroke={color}
@@ -50,9 +56,9 @@
     {#if pulse}
       <rect
         class="pulse"
-        style="transform-origin: {position.x}px {position.y}px;"
-        x={position.x - radius}
-        y={position.y - radius}
+        style="transform-origin: {scaledPos.x}px {scaledPos.y}px;"
+        x={scaledPos.x - radius}
+        y={scaledPos.y - radius}
         height={radius * 2}
         width={radius * 2}
         stroke={color}
@@ -62,8 +68,8 @@
     {/if}
   {:else if shape == 'circle'}
     <circle
-      cx={position.x}
-      cy={position.y}
+      cx={scaledPos.x}
+      cy={scaledPos.y}
       r={radius}
       stroke={color}
       stroke-width={LINE_WIDTH}
@@ -73,9 +79,9 @@
     {#if pulse}
       <circle
         class="pulse"
-        style="transform-origin: {position.x}px {position.y}px;"
-        cx={position.x}
-        cy={position.y}
+        style="transform-origin: {scaledPos.x}px {scaledPos.y}px;"
+        cx={scaledPos.x}
+        cy={scaledPos.y}
         r={radius}
         stroke={color}
         stroke-width={LINE_WIDTH}
@@ -87,7 +93,7 @@
     {@const dx = (triRadius * Math.sqrt(3)) / 2}
     {@const dy = triRadius / 2}
     <polygon
-      points={`${position.x},${position.y + triRadius} ${position.x + dx},${position.y - dy} ${position.x - dx},${position.y - dy}`}
+      points={`${scaledPos.x},${scaledPos.y + triRadius} ${scaledPos.x + dx},${scaledPos.y - dy} ${scaledPos.x - dx},${scaledPos.y - dy}`}
       stroke={color}
       stroke-width={LINE_WIDTH}
       fill={fill ?? color}
@@ -96,8 +102,8 @@
     {#if pulse}
       <polygon
         class="pulse"
-        style="transform-origin: {position.x}px {position.y}px;"
-        points={`${position.x},${position.y + triRadius} ${position.x + dx},${position.y - dy} ${position.x - dx},${position.y - dy}`}
+        style="transform-origin: {scaledPos.x}px {scaledPos.y}px;"
+        points={`${scaledPos.x},${scaledPos.y + triRadius} ${scaledPos.x + dx},${scaledPos.y - dy} ${scaledPos.x - dx},${scaledPos.y - dy}`}
         stroke={color}
         stroke-width={LINE_WIDTH}
         fill={fill ?? color}
@@ -108,10 +114,10 @@
 {#if text}
   {#if showTextOnlyOnHover}
     <g class="hoverText">
-      <Latex2D latex={text} {position} {offset} {fontSize} color={PrimeColor.black} />
+      <Latex2D latex={text} position={scaledPos} {offset} {fontSize} color={PrimeColor.black} />
     </g>
   {:else}
-    <Latex2D latex={text} {position} {offset} {fontSize} color={PrimeColor.black} />
+    <Latex2D latex={text} position={scaledPos} {offset} {fontSize} color={PrimeColor.black} />
   {/if}
 {/if}
 

--- a/src/lib/d3/Polygon2D.svelte
+++ b/src/lib/d3/Polygon2D.svelte
@@ -28,7 +28,9 @@
 
   // Points joined by commas [(1,0,), (0,1)] => "1,0 0,1"
   const pointsJoin = $derived(
-    points.map((p) => new Vector2((p.x + offset.x) * sx, (p.y + offset.y) * sy).toArray().join(',')).join(' ')
+    points
+      .map((p) => new Vector2((p.x + offset.x) * sx, (p.y + offset.y) * sy).toArray().join(','))
+      .join(' ')
   );
 
   const patternId = $derived(`dashed-pattern-${color.replace(/[^a-zA-Z0-9]/g, '')}`);

--- a/src/lib/d3/Polygon2D.svelte
+++ b/src/lib/d3/Polygon2D.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Vector2 } from 'three';
+  import { getContext } from 'svelte';
 
   export type Polygon2DProps = {
     points: Vector2[];
@@ -21,9 +22,13 @@
     fillStyle = 'full'
   }: Polygon2DProps = $props();
 
+  const _scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const sx = _scale2D?.x ?? 1;
+  const sy = _scale2D?.y ?? 1;
+
   // Points joined by commas [(1,0,), (0,1)] => "1,0 0,1"
   const pointsJoin = $derived(
-    points.map((p) => p.clone().add(offset).toArray().join(',')).join(' ')
+    points.map((p) => new Vector2((p.x + offset.x) * sx, (p.y + offset.y) * sy).toArray().join(',')).join(' ')
   );
 
   const patternId = $derived(`dashed-pattern-${color.replace(/[^a-zA-Z0-9]/g, '')}`);

--- a/src/lib/d3/Rect2D.svelte
+++ b/src/lib/d3/Rect2D.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Vector2 } from 'three';
+  import { getContext } from 'svelte';
 
   export type Rectangle2DProps = {
     points: [Vector2, Vector2];
@@ -7,14 +8,20 @@
   };
 
   let { points, color = 'black' }: Rectangle2DProps = $props();
+
+  const _scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const sx = _scale2D?.x ?? 1;
+  const sy = _scale2D?.y ?? 1;
+  const p0 = $derived(new Vector2(points[0].x * sx, points[0].y * sy));
+  const p1 = $derived(new Vector2(points[1].x * sx, points[1].y * sy));
 </script>
 
 <polygon
   points={`
-    ${points[0].x},${points[0].y}
-    ${points[1].x},${points[0].y}
-    ${points[1].x},${points[1].y}
-    ${points[0].x},${points[1].y}
+    ${p0.x},${p0.y}
+    ${p1.x},${p0.y}
+    ${p1.x},${p1.y}
+    ${p0.x},${p1.y}
   `}
   fill={color}
   class="rect-polygon"

--- a/src/lib/d3/RightAngle2D.svelte
+++ b/src/lib/d3/RightAngle2D.svelte
@@ -12,6 +12,7 @@
   import { Vector2 } from 'three';
   import Line from './Line2D.svelte';
   import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { getContext, setContext } from 'svelte';
 
   let {
     vs,
@@ -20,6 +21,14 @@
     color = PrimeColor.black,
     lineWidth = 0.02
   }: RightAngle2DProps = $props();
+
+  const _scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const sx = _scale2D?.x ?? 1;
+  const sy = _scale2D?.y ?? 1;
+  // Prevent Line2D children from applying scale again (coordinates are passed in world space)
+  setContext('scale2D', { x: 1, y: 1 });
+
+  const scaledOrigin = $derived(new Vector2(origin.x * sx, origin.y * sy));
 
   //resize vectors
   const u1 = $derived(vs[0].clone().multiplyScalar(size / vs[0].length()));
@@ -45,13 +54,13 @@
   <Line
     {color}
     width={lineWidth}
-    start={u1.clone().add(origin)}
-    end={u1.clone().add(u2).add(origin)}
+    start={u1.clone().add(scaledOrigin)}
+    end={u1.clone().add(u2).add(scaledOrigin)}
   />
   <Line
     {color}
     width={lineWidth}
-    start={u2.clone().add(origin)}
-    end={u1.clone().add(u2).add(origin)}
+    start={u2.clone().add(scaledOrigin)}
+    end={u1.clone().add(u2).add(scaledOrigin)}
   />
 {/if}

--- a/src/lib/d3/Trajectory2D.svelte
+++ b/src/lib/d3/Trajectory2D.svelte
@@ -30,16 +30,14 @@
   // Prevent children (Point2D, Triangle2D) from applying scale again
   setContext('scale2D', { x: 1, y: 1 });
 
-  const scaledStart = $derived(new Vector2(start.x * sx, start.y * sy));
-
-  const c1 = $derived(0.25 * scaledStart.x + 0.5 * scaledStart.y);
-  const c2 = $derived(0.25 * scaledStart.x - 0.5 * scaledStart.y);
+  const c1 = $derived(0.25 * start.x + 0.5 * start.y);
+  const c2 = $derived(0.25 * start.x - 0.5 * start.y);
   const v1 = new Vector2(2, 1);
   const v2 = new Vector2(2, -1);
 
   const trajectoryPoints = $derived.by(() => {
-    const points = [scaledStart.clone()];
-    let currentPoint = scaledStart.clone();
+    const points = [new Vector2(start.x * sx, start.y * sy)];
+    let currentPoint = start.clone();
 
     function xt(t: number) {
       const vt1 = v1.clone().multiplyScalar(c1 * Math.exp(3 * t));
@@ -70,7 +68,7 @@
 
       currentPoint = point;
 
-      points.push(currentPoint);
+      points.push(new Vector2(currentPoint.x * sx, currentPoint.y * sy));
       iterations++;
     }
 
@@ -92,7 +90,7 @@
   });
 </script>
 
-{#if scaledStart.x / scaledStart.y == -2}
+{#if start.x / start.y == -2}
   <Point2D position={new Vector2()} {color} radius={width ? width * 4 : undefined} />
 {/if}
 

--- a/src/lib/d3/Trajectory2D.svelte
+++ b/src/lib/d3/Trajectory2D.svelte
@@ -4,6 +4,7 @@
   import { Vector2 } from 'three';
   import Point2D from './Point2D.svelte';
   import Triangle2D from './Triangle2D.svelte';
+  import { getContext, setContext } from 'svelte';
 
   type Trajectory2DProps = {
     start: Vector2;
@@ -23,14 +24,22 @@
     tension = 0.5
   }: Trajectory2DProps = $props();
 
-  const c1 = $derived(0.25 * start.x + 0.5 * start.y);
-  const c2 = $derived(0.25 * start.x - 0.5 * start.y);
+  const _scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const sx = _scale2D?.x ?? 1;
+  const sy = _scale2D?.y ?? 1;
+  // Prevent children (Point2D, Triangle2D) from applying scale again
+  setContext('scale2D', { x: 1, y: 1 });
+
+  const scaledStart = $derived(new Vector2(start.x * sx, start.y * sy));
+
+  const c1 = $derived(0.25 * scaledStart.x + 0.5 * scaledStart.y);
+  const c2 = $derived(0.25 * scaledStart.x - 0.5 * scaledStart.y);
   const v1 = new Vector2(2, 1);
   const v2 = new Vector2(2, -1);
 
   const trajectoryPoints = $derived.by(() => {
-    const points = [start.clone()];
-    let currentPoint = start.clone();
+    const points = [scaledStart.clone()];
+    let currentPoint = scaledStart.clone();
 
     function xt(t: number) {
       const vt1 = v1.clone().multiplyScalar(c1 * Math.exp(3 * t));
@@ -83,7 +92,7 @@
   });
 </script>
 
-{#if start.x / start.y == -2}
+{#if scaledStart.x / scaledStart.y == -2}
   <Point2D position={new Vector2()} {color} radius={width ? width * 4 : undefined} />
 {/if}
 

--- a/src/lib/d3/Triangle2D.svelte
+++ b/src/lib/d3/Triangle2D.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Vector2 } from 'three';
+  import { getContext } from 'svelte';
 
   export type Triangle2DProps = {
     points: Vector2[];
@@ -7,6 +8,11 @@
   };
 
   let { points, color = 'black' }: Triangle2DProps = $props();
+
+  const _scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const sx = _scale2D?.x ?? 1;
+  const sy = _scale2D?.y ?? 1;
+  const scaledPoints = $derived(points.map((p) => new Vector2(p.x * sx, p.y * sy)));
 </script>
 
 <!-- @component
@@ -18,4 +24,4 @@
 <Triangle points={[new Vector2(0, 0), new Vector2(1, 0), new Vector2(0, 1)]} />
 -->
 
-<polygon points={points.map((p) => p.x + ',' + p.y).join(' ')} fill={color} />
+<polygon points={scaledPoints.map((p) => p.x + ',' + p.y).join(' ')} fill={color} />

--- a/src/lib/d3/Vector2D.svelte
+++ b/src/lib/d3/Vector2D.svelte
@@ -39,25 +39,27 @@
   const _scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
   const sx = _scale2D?.x ?? 1;
   const sy = _scale2D?.y ?? 1;
-  // Prevent child components (Line2D, Triangle2D, Point2D) from applying scale again
   setContext('scale2D', { x: 1, y: 1 });
-
-  const scaledOrigin = $derived(new Vector2(origin.x * sx, origin.y * sy));
 
   const CONE_HEIGHT = $derived(Math.max(7 * radius, 0.4));
   const CONE_DIAMETER = $derived(Math.max(1.5 * radius, 0.1));
 
   const normalizedDirection = $derived(noNormalise ? direction : direction.clone().normalize());
-
-  const endPoint = $derived(
-    scaledOrigin.clone().add(normalizedDirection.clone().multiplyScalar(length))
-  ); // store with tip of the vector
   const coneHeight = $derived(hideHead ? 0 : headLength !== undefined ? headLength : CONE_HEIGHT);
-
   const coneStart = $derived(length + coneHeight * (length > 0 ? -0.5 : 1.5));
 
-  const coneStartPos = $derived(
-    scaledOrigin.clone().add(normalizedDirection.clone().multiplyScalar(coneStart - coneHeight / 2))
+  const scaledOrigin = $derived(new Vector2(origin.x * sx, origin.y * sy));
+  const displayEnd = $derived(
+    origin.clone().add(normalizedDirection.clone().multiplyScalar(length))
+  );
+  const endPoint = $derived(new Vector2(displayEnd.x * sx, displayEnd.y * sy));
+  const displayConeStart = $derived(
+    origin.clone().add(normalizedDirection.clone().multiplyScalar(coneStart - coneHeight / 2))
+  );
+  const coneStartPos = $derived(new Vector2(displayConeStart.x * sx, displayConeStart.y * sy));
+
+  const worldDirection = $derived(
+    new Vector2(normalizedDirection.x * sx, normalizedDirection.y * sy)
   );
 </script>
 
@@ -79,14 +81,14 @@
 -->
 
 <!-- Line 2D -->
-<Line2D start={origin} end={coneStartPos} {color} width={radius} {isDashed} />
+<Line2D start={scaledOrigin} end={coneStartPos} {color} width={radius} {isDashed} />
 
 {#if !hideHead}
   {#if length == 0}
-    <Point2D position={new Vector2()} {color} />
+    <Point2D position={scaledOrigin} {color} />
   {:else}
     <g
-      transform={`translate(${scaledOrigin.x}, ${scaledOrigin.y}) rotate(${(normalizedDirection.angle() * 180) / Math.PI}) translate(${coneStart - coneHeight / 2}, 0) rotate(${length < 0 ? 90 : -90})`}
+      transform={`translate(${coneStartPos.x}, ${coneStartPos.y}) rotate(${(worldDirection.angle() * 180) / Math.PI + (length < 0 ? 90 : -90)})`}
     >
       <Triangle2D
         points={[

--- a/src/lib/d3/Vector2D.svelte
+++ b/src/lib/d3/Vector2D.svelte
@@ -21,6 +21,7 @@
   import Line2D from './Line2D.svelte';
   import Point2D from './Point2D.svelte';
   import Triangle2D from './Triangle2D.svelte';
+  import { getContext, setContext } from 'svelte';
 
   let {
     color = PrimeColor.getRandomColor(),
@@ -35,18 +36,26 @@
     children
   }: VectorProps = $props();
 
+  const _scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const sx = _scale2D?.x ?? 1;
+  const sy = _scale2D?.y ?? 1;
+  // Prevent child components (Line2D, Triangle2D, Point2D) from applying scale again
+  setContext('scale2D', { x: 1, y: 1 });
+
+  const scaledOrigin = $derived(new Vector2(origin.x * sx, origin.y * sy));
+
   const CONE_HEIGHT = $derived(Math.max(7 * radius, 0.4));
   const CONE_DIAMETER = $derived(Math.max(1.5 * radius, 0.1));
 
   const normalizedDirection = $derived(noNormalise ? direction : direction.clone().normalize());
 
-  const endPoint = $derived(origin.clone().add(normalizedDirection.clone().multiplyScalar(length))); // store with tip of the vector
+  const endPoint = $derived(scaledOrigin.clone().add(normalizedDirection.clone().multiplyScalar(length))); // store with tip of the vector
   const coneHeight = $derived(hideHead ? 0 : headLength !== undefined ? headLength : CONE_HEIGHT);
 
   const coneStart = $derived(length + coneHeight * (length > 0 ? -0.5 : 1.5));
 
   const coneStartPos = $derived(
-    origin.clone().add(normalizedDirection.clone().multiplyScalar(coneStart - coneHeight / 2))
+    scaledOrigin.clone().add(normalizedDirection.clone().multiplyScalar(coneStart - coneHeight / 2))
   );
 </script>
 
@@ -75,7 +84,7 @@
     <Point2D position={new Vector2()} {color} />
   {:else}
     <g
-      transform={`translate(${origin.x}, ${origin.y}) rotate(${(normalizedDirection.angle() * 180) / Math.PI}) translate(${coneStart - coneHeight / 2}, 0) rotate(${length < 0 ? 90 : -90})`}
+      transform={`translate(${scaledOrigin.x}, ${scaledOrigin.y}) rotate(${(normalizedDirection.angle() * 180) / Math.PI}) translate(${coneStart - coneHeight / 2}, 0) rotate(${length < 0 ? 90 : -90})`}
     >
       <Triangle2D
         points={[

--- a/src/lib/d3/Vector2D.svelte
+++ b/src/lib/d3/Vector2D.svelte
@@ -49,7 +49,9 @@
 
   const normalizedDirection = $derived(noNormalise ? direction : direction.clone().normalize());
 
-  const endPoint = $derived(scaledOrigin.clone().add(normalizedDirection.clone().multiplyScalar(length))); // store with tip of the vector
+  const endPoint = $derived(
+    scaledOrigin.clone().add(normalizedDirection.clone().multiplyScalar(length))
+  ); // store with tip of the vector
   const coneHeight = $derived(hideHead ? 0 : headLength !== undefined ? headLength : CONE_HEIGHT);
 
   const coneStart = $derived(length + coneHeight * (length > 0 ? -0.5 : 1.5));

--- a/src/lib/d3/ViewBox.ts
+++ b/src/lib/d3/ViewBox.ts
@@ -4,16 +4,23 @@ export class ViewBox {
   bottomLeft: Vector2;
   topRight: Vector2;
   margin: number;
+  scaleX: number;
+  scaleY: number;
 
   /**
    * ViewBox automatically sets the camera position and zoom in order to make the area defined by it always visible on any screen
    * @param bottomLeft Bottom left corner of the view box
    * @param topRight Top right corner of the view box
    * @param margin Margin of the box to extend the sides with
+   * @param scaleX Scale factor for X axis (optional, default 1)
+   * @param scaleY Scale factor for Y axis (optional, default 1)
    */
-  constructor(bottomLeft: Vector2, topRight: Vector2, margin?: number) {
-    this.bottomLeft = bottomLeft;
-    this.topRight = topRight;
+  constructor(bottomLeft: Vector2, topRight: Vector2, margin?: number, scaleX?: number, scaleY?: number) {
+    this.scaleX = scaleX ?? 1;
+    this.scaleY = scaleY ?? 1;
+    // Apply scales to convert from display-space to world-space
+    this.bottomLeft = new Vector2(bottomLeft.x * this.scaleX, bottomLeft.y * this.scaleY);
+    this.topRight = new Vector2(topRight.x * this.scaleX, topRight.y * this.scaleY);
     this.margin = margin ?? 0;
   }
 

--- a/src/lib/d3/ViewBox.ts
+++ b/src/lib/d3/ViewBox.ts
@@ -15,7 +15,13 @@ export class ViewBox {
    * @param scaleX Scale factor for X axis (optional, default 1)
    * @param scaleY Scale factor for Y axis (optional, default 1)
    */
-  constructor(bottomLeft: Vector2, topRight: Vector2, margin?: number, scaleX?: number, scaleY?: number) {
+  constructor(
+    bottomLeft: Vector2,
+    topRight: Vector2,
+    margin?: number,
+    scaleX?: number,
+    scaleY?: number
+  ) {
     this.scaleX = scaleX ?? 1;
     this.scaleY = scaleY ?? 1;
     // Apply scales to convert from display-space to world-space

--- a/src/lib/stories/Canvas2D.stories.svelte
+++ b/src/lib/stories/Canvas2D.stories.svelte
@@ -86,15 +86,14 @@
   {/snippet}
 </Story>
 
-<!-- This story has a scaled X axis -->
+<!-- This story has a scaled X axis. Pass scaleX and/or scaleY to Canvas2D to change the coordinate system scale.
+All child components (axis, functions, points, lines, vectors) auto-scale accordingly.
+scaleX/scaleY define how many SVG units correspond to 1 display unit.
+With scaleX=2, the axis label "1" appears at SVG position x=2. Positions and formulas should use display (math) space. -->
 <Story name="Scaled axis">
   {#snippet template(_args)}
     <div class="h-[300px] overflow-hidden rounded-lg">
-      <Canvas2D
-        axis={{
-          scaleX: 2
-        }}
-      >
+      <Canvas2D scaleX={2}>
         <Vector2D direction={new Vector2(2, 2)} color={PrimeColor.blue} length={2} />
       </Canvas2D>
     </div>
@@ -102,6 +101,17 @@
 </Story>
 
 <!-- This story has a skipped X ticks -->
+<!-- This story has a non-uniform scale: scaleX=1.5, scaleY=3. The vector position (1, 1) in display space maps to (1.5, 3) in SVG space. -->
+<Story name="Non-uniform scale">
+  {#snippet template(_args)}
+    <div class="h-[300px] overflow-hidden rounded-lg">
+      <Canvas2D scaleX={1.5} scaleY={3}>
+        <Vector2D direction={new Vector2(1, 1)} color={PrimeColor.blue} length={1} />
+      </Canvas2D>
+    </div>
+  {/snippet}
+</Story>
+
 <Story name="Skipped axis">
   {#snippet template(_args)}
     <div class="h-[300px] overflow-hidden rounded-lg">

--- a/src/routes/applet/calculus/definite_integrals/an_interval_training/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/an_interval_training/+page.svelte
@@ -56,7 +56,6 @@
     new Vector2(12, 12), // top-right
     0.5 // margin
   );
-  /* eslint-disable @typescript-eslint/no-unused-vars */
 
   // ####
   // AXIS

--- a/src/routes/applet/calculus/definite_integrals/an_interval_training/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/an_interval_training/+page.svelte
@@ -74,8 +74,6 @@
     showAxisNumbersY: true,
     logarithmicX: false,
     logarithmicY: false,
-    scaleX: sX,
-    scaleY: sY,
     skipX: 0,
     skipY: 0
   };
@@ -92,48 +90,48 @@
   // APPLET OBJECTS
   // ##############
   const appletObjects: AppletObject[] = [
-    new FunctionFragment('5*' + sY, PrimeColor.blue, {
-      domain: { xMin: 0, xMax: 5 * sX },
+    new FunctionFragment('5', PrimeColor.blue, {
+      domain: { xMin: 0, xMax: 5 },
       legendText: 'v(t)',
       integral: {
         xLeft: 0,
-        xRight: 5 * sX,
+        xRight: 5,
         isDashed: false,
         color: PrimeColor.darkGreen
       }
     }),
-    new FunctionFragment('15*' + sY, PrimeColor.blue, {
-      domain: { xMin: 5 * sX, xMax: 7 * sX },
+    new FunctionFragment('15', PrimeColor.blue, {
+      domain: { xMin: 5, xMax: 7 },
       integral: {
-        xLeft: 5 * sX,
-        xRight: 7 * sX,
+        xLeft: 5,
+        xRight: 7,
         isDashed: false,
         color: PrimeColor.raspberry
       }
     }),
-    new FunctionFragment('6*' + sY, PrimeColor.blue, {
-      domain: { xMin: 7 * sX, xMax: 11 * sX },
+    new FunctionFragment('6', PrimeColor.blue, {
+      domain: { xMin: 7, xMax: 11 },
       integral: {
-        xLeft: 7 * sX,
-        xRight: 11 * sX,
+        xLeft: 7,
+        xRight: 11,
         isDashed: false,
         color: PrimeColor.yellow
       }
     }),
-    new FunctionFragment('20*' + sY, PrimeColor.blue, {
-      domain: { xMin: 11 * sX, xMax: 14 * sX },
+    new FunctionFragment('20', PrimeColor.blue, {
+      domain: { xMin: 11, xMax: 14 },
       integral: {
-        xLeft: 11 * sX,
-        xRight: 14 * sX,
+        xLeft: 11,
+        xRight: 14,
         isDashed: false,
         color: PrimeColor.cyan
       }
     }),
-    new FunctionFragment('4*' + sY, PrimeColor.blue, {
-      domain: { xMin: 14 * sX, xMax: 20 * sX },
+    new FunctionFragment('4', PrimeColor.blue, {
+      domain: { xMin: 14, xMax: 20 },
       integral: {
-        xLeft: 14 * sX,
-        xRight: 20 * sX,
+        xLeft: 14,
+        xRight: 20,
         isDashed: false,
         color: PrimeColor.orange
       }
@@ -147,6 +145,8 @@
   {cameraZoom}
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+  scaleX={sX}
+  scaleY={sY}
   {axis}
 >
   <TemplateComponent objects={appletObjects} />

--- a/src/routes/applet/calculus/definite_integrals/cosine_area/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/cosine_area/+page.svelte
@@ -90,10 +90,10 @@
     skipX={100}
     skipY={2}
     showAxisNumbersX={false}
-    additionalTicksX={[0.5 * Math.PI * sX, Math.PI * sX, 1.5 * Math.PI * sX, 2 * Math.PI * sX]}
+    additionalTicksX={[0.5 * Math.PI, Math.PI, 1.5 * Math.PI, 2 * Math.PI]}
   />
-  <Latex2D latex="\frac12\pi" position={new Vector2(0.5 * Math.PI * sX, -0.15)} alignX="right" />
-  <Latex2D latex="\pi" position={new Vector2(Math.PI * sX, 0.15)} alignX="center" alignY="bottom" />
-  <Latex2D latex="\frac32\pi" position={new Vector2(1.5 * Math.PI * sX, -0.15)} alignX="left" />
-  <Latex2D latex="2\pi" position={new Vector2(2 * Math.PI * sX, -0.15)} alignX="center" />
+  <Latex2D latex="\frac12\pi" position={new Vector2(0.5 * Math.PI, -0.15)} alignX="right" />
+  <Latex2D latex="\pi" position={new Vector2(Math.PI, 0.15)} alignX="center" alignY="bottom" />
+  <Latex2D latex="\frac32\pi" position={new Vector2(1.5 * Math.PI, -0.15)} alignX="left" />
+  <Latex2D latex="2\pi" position={new Vector2(2 * Math.PI, -0.15)} alignX="center" />
 </Canvas2D>

--- a/src/routes/applet/calculus/definite_integrals/cosine_area/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/cosine_area/+page.svelte
@@ -60,11 +60,11 @@
   // APPLET OBJECTS
   // ##############
   const appletObjects: AppletObject[] = [
-    new FunctionFragment(sY + '\\cos(x/' + sX + ')', PrimeColor.blue, {
-      domain: { xMin: 0, xMax: 2 * Math.PI * sX },
+    new FunctionFragment('\\cos(x)', PrimeColor.blue, {
+      domain: { xMin: 0, xMax: 2 * Math.PI },
       integral: {
         xLeft: 0,
-        xRight: 2 * Math.PI * sX,
+        xRight: 2 * Math.PI,
         legendText: '\\int_{0}^{2\\pi} \\cos(x) dx',
         isDashed: false,
         color: PrimeColor.darkGreen,
@@ -81,13 +81,13 @@
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
   legendFormulaPosition="top-right"
+  scaleX={sX}
+  scaleY={sY}
   axis={null}
 >
   <TemplateComponent objects={appletObjects} />
   <Axis
-    scaleX={sX}
     skipX={100}
-    scaleY={sY}
     skipY={2}
     showAxisNumbersX={false}
     additionalTicksX={[0.5 * Math.PI * sX, Math.PI * sX, 1.5 * Math.PI * sX, 2 * Math.PI * sX]}

--- a/src/routes/applet/calculus/definite_integrals/linear_function/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/linear_function/+page.svelte
@@ -81,5 +81,5 @@
   axis={null}
 >
   <TemplateComponent objects={appletObjects} />
-  <Axis scaleX={1} skipX={0} />
+  <Axis skipX={0} />
 </Canvas2D>

--- a/src/routes/applet/calculus/definite_integrals/piecewise_function/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/piecewise_function/+page.svelte
@@ -52,47 +52,44 @@
   xAxisLabel = 'x';
   yAxisLabel = 'y';
 
-  let sX = 1;
-  let sY = 1;
-
   // ##############
   // APPLET OBJECTS
   // ##############
   const appletObjects: AppletObject[] = [
-    new FunctionFragment(sY + '*(x/' + sX + ')', PrimeColor.blue, {
+    new FunctionFragment('x', PrimeColor.blue, {
       legendText:
         'f(x)=\\left\\{\\begin{array}{ll}x, & 0\\leq x<1,\\\\2, & 1\\leq x\\leq 2,\\\\x-1, & 2<x\\leq 3.\\end{array}\\right.',
-      domain: { xMin: 0, xMax: 1 * sX },
+      domain: { xMin: 0, xMax: 1 },
       integral: {
         xLeft: 0,
-        xRight: 1 * sX,
+        xRight: 1,
         legendText: '\\int_{0}^{3} f(x) dx',
         isDashed: false,
         color: PrimeColor.darkGreen,
         shape: 'square'
       }
     })
-      .addGaps([new Vector2(1 * sX, 1 * sY), new Vector2(2 * sX, 1 * sY)])
+      .addGaps([new Vector2(1, 1), new Vector2(2, 1)])
       .addIncludedPoints([
-        new Vector2(0 * sX, 0 * sY),
-        new Vector2(1 * sX, 2 * sY),
-        new Vector2(2 * sX, 2 * sY),
-        new Vector2(3 * sX, 2 * sY)
+        new Vector2(0, 0),
+        new Vector2(1, 2),
+        new Vector2(2, 2),
+        new Vector2(3, 2)
       ]),
-    new FunctionFragment(sY + '*2', PrimeColor.blue, {
-      domain: { xMin: 1 * sX, xMax: 2 * sX },
+    new FunctionFragment('2', PrimeColor.blue, {
+      domain: { xMin: 1, xMax: 2 },
       integral: {
-        xLeft: 1 * sX,
-        xRight: 2 * sX,
+        xLeft: 1,
+        xRight: 2,
         isDashed: false,
         color: PrimeColor.darkGreen
       }
     }),
-    new FunctionFragment(sY + '*(x/' + sX + '-1)', PrimeColor.blue, {
-      domain: { xMin: 2 * sX, xMax: 3 * sX },
+    new FunctionFragment('x-1', PrimeColor.blue, {
+      domain: { xMin: 2, xMax: 3 },
       integral: {
-        xLeft: 2 * sX,
-        xRight: 3 * sX,
+        xLeft: 2,
+        xRight: 3,
         isDashed: false,
         color: PrimeColor.darkGreen
       }
@@ -110,5 +107,5 @@
   axis={null}
 >
   <TemplateComponent objects={appletObjects} />
-  <Axis scaleX={sX} skipX={0} scaleY={sY} skipY={0} />
+  <Axis skipX={0} skipY={0} />
 </Canvas2D>

--- a/src/routes/applet/calculus/definite_integrals/piecewise_function_with_negative_and_positive_values/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/piecewise_function_with_negative_and_positive_values/+page.svelte
@@ -52,9 +52,6 @@
   xAxisLabel = 'x';
   yAxisLabel = 'y';
 
-  let sX = 1;
-  let sY = 1;
-
   // ##############
   // APPLET OBJECTS
   // ##############
@@ -111,5 +108,5 @@
   axis={null}
 >
   <TemplateComponent objects={appletObjects} />
-  <Axis scaleX={sX} skipX={0} scaleY={sY} skipY={0} />
+  <Axis skipX={0} skipY={0} />
 </Canvas2D>

--- a/src/routes/applet/calculus/definite_integrals/positive_and_negative_values/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/positive_and_negative_values/+page.svelte
@@ -61,31 +61,31 @@
   // APPLET OBJECTS
   // ##############
   const appletObjects: AppletObject[] = [
-    new FunctionFragment(sY + '\\cos((x-' + shiftX * sX + ')/' + sX + ')', PrimeColor.blue, {
-      domain: { xMin: 0 + shiftX * sX, xMax: 0.5 * Math.PI * sX + shiftX * sX },
+    new FunctionFragment('\\cos(x-' + shiftX + ')', PrimeColor.blue, {
+      domain: { xMin: 0 + shiftX, xMax: 0.5 * Math.PI + shiftX },
       legendText: 'f(x)',
       integral: {
-        xLeft: 0 + shiftX * sX,
-        xRight: 0.5 * Math.PI * sX + shiftX * sX,
+        xLeft: 0 + shiftX,
+        xRight: 0.5 * Math.PI + shiftX,
         isDashed: false,
         color: PrimeColor.darkGreen
       }
     }),
-    new FunctionFragment(sY + '\\cos((x-' + shiftX * sX + ')/' + sX + ')', PrimeColor.blue, {
-      domain: { xMin: 0.5 * Math.PI * sX + shiftX * sX, xMax: 1.5 * Math.PI * sX + shiftX * sX },
+    new FunctionFragment('\\cos(x-' + shiftX + ')', PrimeColor.blue, {
+      domain: { xMin: 0.5 * Math.PI + shiftX, xMax: 1.5 * Math.PI + shiftX },
       integral: {
-        xLeft: 0.5 * Math.PI * sX + shiftX * sX,
-        xRight: 1.5 * Math.PI * sX + shiftX * sX,
+        xLeft: 0.5 * Math.PI + shiftX,
+        xRight: 1.5 * Math.PI + shiftX,
         isDashed: false,
         color: PrimeColor.raspberry,
         shape: 'square'
       }
     }),
-    new FunctionFragment(sY + '\\cos((x-' + shiftX * sX + ')/' + sX + ')', PrimeColor.blue, {
-      domain: { xMin: 1.5 * Math.PI * sX + shiftX * sX, xMax: 2 * Math.PI * sX + shiftX * sX },
+    new FunctionFragment('\\cos(x-' + shiftX + ')', PrimeColor.blue, {
+      domain: { xMin: 1.5 * Math.PI + shiftX, xMax: 2 * Math.PI + shiftX },
       integral: {
-        xLeft: 1.5 * Math.PI * sX + shiftX * sX,
-        xRight: 2 * Math.PI * sX + shiftX * sX,
+        xLeft: 1.5 * Math.PI + shiftX,
+        xRight: 2 * Math.PI + shiftX,
         isDashed: false,
         color: PrimeColor.darkGreen,
         shape: 'square'
@@ -101,13 +101,13 @@
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
   legendFormulaPosition="top-right"
+  scaleX={sX}
+  scaleY={sY}
   axis={null}
 >
   <TemplateComponent objects={appletObjects} />
   <Axis
-    scaleX={sX}
     skipX={100}
-    scaleY={sY}
     skipY={300}
     showAxisNumbersX={false}
     showAxisNumbersY={false}

--- a/src/routes/applet/calculus/definite_integrals/positive_and_negative_values/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/positive_and_negative_values/+page.svelte
@@ -114,33 +114,33 @@
     showGridLinesX={false}
     showGridLinesY={false}
     additionalTicksX={[
-      0 + shiftX * sX,
-      2 * Math.PI * sX + shiftX * sX,
-      0.5 * Math.PI * sX + shiftX * sX
+      0 + shiftX,
+      2 * Math.PI + shiftX,
+      0.5 * Math.PI + shiftX
     ]}
   />
-  <Latex2D latex="a" position={new Vector2(0 + shiftX * sX, -0.15)} alignX="center" />
+  <Latex2D latex="a" position={new Vector2(0 + shiftX, -0.15)} alignX="center" />
 
   <Latex2D
     latex="b"
-    position={new Vector2(2 * Math.PI * sX + shiftX * sX, -0.15)}
+    position={new Vector2(2 * Math.PI + shiftX, -0.15)}
     alignX="center"
   />
   <Latex2D
     latex={'\\boldsymbol{+}'}
-    position={new Vector2((2 / Math.PI) * sX + shiftX * sX, 0.5 * sY)}
+    position={new Vector2((2 / Math.PI) + shiftX, 0.5)}
     alignX="center"
     alignY="top"
   />
   <Latex2D
     latex={'\\boldsymbol{+}'}
-    position={new Vector2((-2 / Math.PI) * sX + 2 * Math.PI * sX + shiftX * sX, 0.5 * sY)}
+    position={new Vector2((-2 / Math.PI) + 2 * Math.PI + shiftX, 0.5)}
     alignX="center"
     alignY="top"
   />
   <Latex2D
     latex={'\\boldsymbol{-}'}
-    position={new Vector2(Math.PI * sX + shiftX * sX, -0.5 * sY)}
+    position={new Vector2(Math.PI + shiftX, -0.5)}
     alignX="center"
     alignY="bottom"
   />

--- a/src/routes/applet/calculus/definite_integrals/positive_and_negative_values/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/positive_and_negative_values/+page.svelte
@@ -113,28 +113,20 @@
     showAxisNumbersY={false}
     showGridLinesX={false}
     showGridLinesY={false}
-    additionalTicksX={[
-      0 + shiftX,
-      2 * Math.PI + shiftX,
-      0.5 * Math.PI + shiftX
-    ]}
+    additionalTicksX={[0 + shiftX, 2 * Math.PI + shiftX, 0.5 * Math.PI + shiftX]}
   />
   <Latex2D latex="a" position={new Vector2(0 + shiftX, -0.15)} alignX="center" />
 
-  <Latex2D
-    latex="b"
-    position={new Vector2(2 * Math.PI + shiftX, -0.15)}
-    alignX="center"
-  />
+  <Latex2D latex="b" position={new Vector2(2 * Math.PI + shiftX, -0.15)} alignX="center" />
   <Latex2D
     latex={'\\boldsymbol{+}'}
-    position={new Vector2((2 / Math.PI) + shiftX, 0.5)}
+    position={new Vector2(2 / Math.PI + shiftX, 0.5)}
     alignX="center"
     alignY="top"
   />
   <Latex2D
     latex={'\\boldsymbol{+}'}
-    position={new Vector2((-2 / Math.PI) + 2 * Math.PI + shiftX, 0.5)}
+    position={new Vector2(-2 / Math.PI + 2 * Math.PI + shiftX, 0.5)}
     alignX="center"
     alignY="top"
   />

--- a/src/routes/applet/calculus/definite_integrals/sine_area/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/sine_area/+page.svelte
@@ -101,10 +101,5 @@
     alignX="center"
     alignY="bottom"
   />
-  <Latex2D
-    latex="-\pi"
-    position={new Vector2(-Math.PI, 0.15)}
-    alignX="center"
-    alignY="bottom"
-  />
+  <Latex2D latex="-\pi" position={new Vector2(-Math.PI, 0.15)} alignX="center" alignY="bottom" />
 </Canvas2D>

--- a/src/routes/applet/calculus/definite_integrals/sine_area/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/sine_area/+page.svelte
@@ -60,12 +60,12 @@
   // APPLET OBJECTS
   // ##############
   const appletObjects: AppletObject[] = [
-    new FunctionFragment(sY + '\\sin(x/' + sX + ')', PrimeColor.blue, {
-      domain: { xMin: -Math.PI * sX, xMax: Math.PI * sX },
+    new FunctionFragment('\\sin(x)', PrimeColor.blue, {
+      domain: { xMin: -Math.PI, xMax: Math.PI },
       legendText: '\\sin(x)',
       integral: {
-        xLeft: (-1 / 2) * Math.PI * sX,
-        xRight: (1 / 2) * Math.PI * sX,
+        xLeft: (-1 / 2) * Math.PI,
+        xRight: (1 / 2) * Math.PI,
         legendText: '\\int_{-\\frac12\\pi}^{\\frac12\\pi} \\sin(x) dx',
         isDashed: false,
         color: PrimeColor.darkGreen,
@@ -82,13 +82,13 @@
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
   legendFormulaPosition="top-left"
+  scaleX={sX}
+  scaleY={sY}
   axis={null}
 >
   <TemplateComponent objects={appletObjects} />
   <Axis
-    scaleX={sX}
     skipX={100}
-    scaleY={sY}
     skipY={2}
     showAxisNumbersX={false}
     additionalTicksX={[-0.5 * Math.PI * sX, Math.PI * sX, 0.5 * Math.PI * sX, -Math.PI * sX]}

--- a/src/routes/applet/calculus/definite_integrals/sine_area/+page.svelte
+++ b/src/routes/applet/calculus/definite_integrals/sine_area/+page.svelte
@@ -91,19 +91,19 @@
     skipX={100}
     skipY={2}
     showAxisNumbersX={false}
-    additionalTicksX={[-0.5 * Math.PI * sX, Math.PI * sX, 0.5 * Math.PI * sX, -Math.PI * sX]}
+    additionalTicksX={[-0.5 * Math.PI, Math.PI, 0.5 * Math.PI, -Math.PI]}
   />
-  <Latex2D latex="\frac12\pi" position={new Vector2(0.5 * Math.PI * sX, -0.15)} alignX="right" />
-  <Latex2D latex="\pi" position={new Vector2(Math.PI * sX, -0.15)} alignX="center" />
+  <Latex2D latex="\frac12\pi" position={new Vector2(0.5 * Math.PI, -0.15)} alignX="right" />
+  <Latex2D latex="\pi" position={new Vector2(Math.PI, -0.15)} alignX="center" />
   <Latex2D
     latex="-\frac12\pi"
-    position={new Vector2(-0.5 * Math.PI * sX, 0.15)}
+    position={new Vector2(-0.5 * Math.PI, 0.15)}
     alignX="center"
     alignY="bottom"
   />
   <Latex2D
     latex="-\pi"
-    position={new Vector2(-Math.PI * sX, 0.15)}
+    position={new Vector2(-Math.PI, 0.15)}
     alignX="center"
     alignY="bottom"
   />

--- a/src/routes/applet/calculus/indefinite_integrals/a_function/+page.svelte
+++ b/src/routes/applet/calculus/indefinite_integrals/a_function/+page.svelte
@@ -59,8 +59,6 @@
     showAxisNumbersY: true,
     logarithmicX: false,
     logarithmicY: false,
-    scaleX: 1,
-    scaleY: 1,
     skipX: 0,
     skipY: 0
   };

--- a/src/routes/applet/calculus/indefinite_integrals/several_functions/+page.svelte
+++ b/src/routes/applet/calculus/indefinite_integrals/several_functions/+page.svelte
@@ -64,8 +64,6 @@
     showAxisNumbersY: true,
     logarithmicX: false,
     logarithmicY: false,
-    scaleX: scaleX,
-    scaleY: scaleY,
     skipX: 0,
     skipY: 0
   };
@@ -134,23 +132,25 @@
   {cameraZoom}
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+  {scaleX}
+  {scaleY}
   {axis}
   controls={toggleControls}
 >
   <TemplateComponent objects={appletObjects} />
   {#if toggleControls[0]}
-    <ExplicitFunction2D func={(x: number) => F(x / scaleX) * scaleY} color={PrimeColor.blue} />
+    <ExplicitFunction2D func={F} color={PrimeColor.blue} />
   {/if}
   {#if toggleControls[1]}
-    <ExplicitFunction2D func={(x: number) => G(x / scaleX) * scaleY} color={PrimeColor.orange} />
+    <ExplicitFunction2D func={G} color={PrimeColor.orange} />
   {/if}
   {#if toggleControls[2]}
-    <ExplicitFunction2D func={(x: number) => H(x / scaleX) * scaleY} color={PrimeColor.darkGreen} />
+    <ExplicitFunction2D func={H} color={PrimeColor.darkGreen} />
   {/if}
   {#if toggleControls[3]}
-    <ExplicitFunction2D func={(x: number) => K(x / scaleX) * scaleY} color={PrimeColor.raspberry} />
+    <ExplicitFunction2D func={K} color={PrimeColor.raspberry} />
   {/if}
   {#if toggleControls[4]}
-    <ExplicitFunction2D func={(x: number) => L(x / scaleX) * scaleY} color={PrimeColor.yellow} />
+    <ExplicitFunction2D func={L} color={PrimeColor.yellow} />
   {/if}
 </Canvas2D>

--- a/src/routes/applet/calculus/integration/method_errors/+page.svelte
+++ b/src/routes/applet/calculus/integration/method_errors/+page.svelte
@@ -137,11 +137,11 @@
   {controls}
   {formulas}
   {legendItems}
+  scaleX={2}
   axis={{
     showOrigin: false,
     logarithmicX: true,
-    logarithmicY: true,
-    scaleX: 2
+    logarithmicY: true
   }}
   cameraZoom={1.15}
   cameraPosition={new Vector2(-1.4, -2.4)}
@@ -156,7 +156,7 @@
   }}
 >
   {#each errorsPredefined as pE (pE.pointX)}
-    {@const x = 2 * Math.log10(pE.pointX)}
+    {@const x = Math.log10(pE.pointX)}
     {@const left = Math.log10(pE.errors['left'])}
     {@const right = Math.log10(pE.errors['right'])}
     {@const trapezoid = Math.log10(pE.errors['trapezoid'])}
@@ -185,7 +185,7 @@
     {/if}
   {/each}
 
-  {@const hX = 2 * Math.log10(h)}
+  {@const hX = Math.log10(h)}
   {@const opacity = animationOn ? 1 : 0.5}
 
   {#if controls[1]}

--- a/src/routes/applet/calculus/inverse_functions/right-angled_triangle/+page.svelte
+++ b/src/routes/applet/calculus/inverse_functions/right-angled_triangle/+page.svelte
@@ -64,8 +64,6 @@
     showAxisNumbersY: true,
     logarithmicX: false,
     logarithmicY: false,
-    scaleX: 1,
-    scaleY: 1,
     skipX: 0,
     skipY: 0
   };

--- a/src/routes/applet/calculus/inverse_functions/right-angled_triangle_for_cosine_of_arcsine_of_x/+page.svelte
+++ b/src/routes/applet/calculus/inverse_functions/right-angled_triangle_for_cosine_of_arcsine_of_x/+page.svelte
@@ -64,8 +64,6 @@
     showAxisNumbersY: true,
     logarithmicX: false,
     logarithmicY: false,
-    scaleX: 1,
-    scaleY: 1,
     skipX: 0,
     skipY: 0
   };

--- a/src/routes/applet/calculus/limits_at_a_point/a_function_with_two_vertical_asymptotes/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/a_function_with_two_vertical_asymptotes/+page.svelte
@@ -55,7 +55,7 @@
   // APPLET OBJECTS
   // ##############
   const appletObjects: AppletObject[] = [
-    new FunctionFragment('\\frac{1}{(x-1)(x-2)^2}/3', PrimeColor.blue, {
+    new FunctionFragment('\\frac{1}{(x-1)(x-2)^2}', PrimeColor.blue, {
       isDashed: false,
       shape: 'circle',
       legendText: 'f(x)=\\frac{1}{(x-1)(x-2)^2}'
@@ -81,9 +81,7 @@
   {cameraZoom}
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
-  axis={{
-    scaleY: 1 / 3
-  }}
+  scaleY={1 / 3}
 >
   <TemplateComponent objects={appletObjects} />
 </Canvas2D>

--- a/src/routes/applet/calculus/limits_at_a_point/two_parabolas_and_an_oscillating_function/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_a_point/two_parabolas_and_an_oscillating_function/+page.svelte
@@ -55,17 +55,17 @@
   // APPLET OBJECTS
   // ##############
   const appletObjects: AppletObject[] = [
-    new FunctionFragment('-(x/4)^2*2', PrimeColor.blue, {
+    new FunctionFragment('-x^2', PrimeColor.blue, {
       isDashed: false,
       shape: 'circle',
       legendText: 'f(x)=-x^2'
     }),
-    new FunctionFragment('(x/4)^2\\sin\\left(\\frac{1}{x/4}\\right)*2', PrimeColor.raspberry, {
+    new FunctionFragment('x^2\\sin\\left(\\frac{1}{x}\\right)', PrimeColor.raspberry, {
       isDashed: false,
       shape: 'square',
       legendText: 'g(x)=x^2\\sin\\left(\\frac{1}{x}\\right)'
     }),
-    new FunctionFragment('(x/4)^2*2', PrimeColor.darkGreen, {
+    new FunctionFragment('x^2', PrimeColor.darkGreen, {
       isDashed: false,
       shape: 'square',
       legendText: 'h(x)=x^2'
@@ -79,9 +79,9 @@
   {cameraZoom}
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+  scaleX={4}
+  scaleY={2}
   axis={{
-    scaleX: 4,
-    scaleY: 2,
     skipX: 1
   }}
 >

--- a/src/routes/applet/calculus/limits_at_infinity/a_function_with_limit_2_at_infinity/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_infinity/a_function_with_limit_2_at_infinity/+page.svelte
@@ -58,15 +58,11 @@
   // APPLET OBJECTS
   // ##############
   const appletObjects: AppletObject[] = [
-    new FunctionFragment(
-      '\\frac{4+\\frac{1}{x}}{2-\\frac{3}{x^2}}',
-      PrimeColor.blue,
-      {
-        isDashed: false,
-        shape: 'circle',
-        legendText: 'f(x)=\\frac{4+\\frac{1}{x}}{2-\\frac{3}{x^2}}'
-      }
-    ).addGaps(new Vector2(0, 0)),
+    new FunctionFragment('\\frac{4+\\frac{1}{x}}{2-\\frac{3}{x^2}}', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      legendText: 'f(x)=\\frac{4+\\frac{1}{x}}{2-\\frac{3}{x^2}}'
+    }).addGaps(new Vector2(0, 0)),
     new FunctionFragment('2', PrimeColor.darkGreen, {
       isDashed: true,
       shape: 'triangle',

--- a/src/routes/applet/calculus/limits_at_infinity/a_function_with_limit_2_at_infinity/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_infinity/a_function_with_limit_2_at_infinity/+page.svelte
@@ -59,7 +59,7 @@
   // ##############
   const appletObjects: AppletObject[] = [
     new FunctionFragment(
-      scaleY + '\\frac{4+\\frac{1}{' + 1 / scaleX + ' x}}{2-\\frac{3}{(' + 1 / scaleX + ' x)^2}}',
+      '\\frac{4+\\frac{1}{x}}{2-\\frac{3}{x^2}}',
       PrimeColor.blue,
       {
         isDashed: false,
@@ -67,7 +67,7 @@
         legendText: 'f(x)=\\frac{4+\\frac{1}{x}}{2-\\frac{3}{x^2}}'
       }
     ).addGaps(new Vector2(0, 0)),
-    new FunctionFragment('2*' + scaleY, PrimeColor.darkGreen, {
+    new FunctionFragment('2', PrimeColor.darkGreen, {
       isDashed: true,
       shape: 'triangle',
       legendText: 'y=2'
@@ -77,8 +77,8 @@
       shape: 'triangle',
       legendText: 'x=\\pm\\sqrt{\\frac{3}{2}}'
     }),
-    new AsymptoteFragment(Math.sqrt(1.5) * scaleX, 'vertical', PrimeColor.raspberry),
-    new AsymptoteFragment(-Math.sqrt(1.5) * scaleX, 'vertical', PrimeColor.raspberry)
+    new AsymptoteFragment(Math.sqrt(1.5), 'vertical', PrimeColor.raspberry),
+    new AsymptoteFragment(-Math.sqrt(1.5), 'vertical', PrimeColor.raspberry)
   ];
 </script>
 
@@ -88,10 +88,8 @@
   {cameraZoom}
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
-  axis={{
-    scaleX,
-    scaleY
-  }}
+  {scaleX}
+  {scaleY}
 >
   <TemplateComponent objects={appletObjects} />
 </Canvas2D>

--- a/src/routes/applet/calculus/limits_at_infinity/limit_of_arctan_at_infinity/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_infinity/limit_of_arctan_at_infinity/+page.svelte
@@ -71,9 +71,7 @@
     label: 'ε'
   });
   let N = $derived(
-    controls[0] >= Math.PI
-      ? -30
-      : Math.min(Math.max(-30, Math.tan(Math.PI / 2 - controls[0])), 30) // To make sure the vertical lines don't intersect with the function
+    controls[0] >= Math.PI ? -30 : Math.min(Math.max(-30, Math.tan(Math.PI / 2 - controls[0])), 30) // To make sure the vertical lines don't intersect with the function
   );
   const appletObjects: AppletObject[] = [
     new FunctionFragment('\\arctan(x)', PrimeColor.blue, {

--- a/src/routes/applet/calculus/limits_at_infinity/limit_of_arctan_at_infinity/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_infinity/limit_of_arctan_at_infinity/+page.svelte
@@ -72,11 +72,11 @@
   });
   let N = $derived(
     controls[0] >= Math.PI
-      ? -30 / factorX
-      : Math.min(Math.max(-30 / factorX, Math.tan(Math.PI / 2 - controls[0])), 30 / factorX) // To make sure the vertical lines don't intersect with the function
+      ? -30
+      : Math.min(Math.max(-30, Math.tan(Math.PI / 2 - controls[0])), 30) // To make sure the vertical lines don't intersect with the function
   );
   const appletObjects: AppletObject[] = [
-    new FunctionFragment(factorY + '*\\arctan(x*' + 1 / factorX + ')', PrimeColor.blue, {
+    new FunctionFragment('\\arctan(x)', PrimeColor.blue, {
       isDashed: false,
       shape: 'square',
       legendText: '\\arctan(x)'
@@ -106,29 +106,25 @@
   {cameraZoom}
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
-  axis={{
-    scaleX: factorX,
-    scaleY: factorY
-  }}
+  scaleX={factorX}
+  scaleY={factorY}
   legendFormulaPosition="top-left"
   splitCanvas2DProps={{
     labels: { xLabel: 'x', yLabel: 'y' },
-    axis: {
-      scaleX: factorY,
-      scaleY: factorX
-    }
+    scaleX: factorY,
+    scaleY: factorX
   }}
 >
   <TemplateComponent objects={appletObjects} />
   <InfiniteLine2D
     direction={new Vector2(1, 0)}
-    origin={new Vector2(0, factorY * (Math.PI / 2 - controls[0]))}
+    origin={new Vector2(0, Math.PI / 2 - controls[0])}
     color={PrimeColor.orange}
     isDashed={true}
   />
   <InfiniteLine2D
     direction={new Vector2(0, 1)}
-    origin={new Vector2(N * factorX, 0)}
+    origin={new Vector2(N, 0)}
     color={PrimeColor.darkGreen}
     isDashed={true}
   />
@@ -136,21 +132,21 @@
   {#snippet splitCanvas2DChildren()}
     <InfiniteLine2D
       direction={new Vector2(0, 1)}
-      origin={new Vector2(factorY * (Math.PI / 2 - controls[0]), 0)}
+      origin={new Vector2(Math.PI / 2 - controls[0], 0)}
       color={PrimeColor.orange}
       isDashed={true}
     />
     <InfiniteLine2D
       direction={new Vector2(1, 0)}
-      origin={new Vector2(0, N * factorX)}
+      origin={new Vector2(0, N)}
       color={PrimeColor.darkGreen}
       isDashed={true}
     />
     <ExplicitFunction2D
-      func={(x: number) => Math.tan(x / factorY) * factorX}
+      func={(x: number) => Math.tan(x)}
       color={PrimeColor.black}
-      xMin={(-Math.PI / 2) * factorY}
-      xMax={(Math.PI / 2) * factorY}
+      xMin={-Math.PI / 2}
+      xMax={Math.PI / 2}
     />
   {/snippet}
 </Canvas2D>

--- a/src/routes/applet/calculus/limits_at_infinity/one_over_one_plus_e_to_the_minus_x/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_infinity/one_over_one_plus_e_to_the_minus_x/+page.svelte
@@ -58,17 +58,17 @@
   // APPLET OBJECTS
   // ##############
   const appletObjects: AppletObject[] = [
-    new FunctionFragment(scaleY + '\\frac{1}{1+e^{-' + 1 / scaleX + 'x}}', PrimeColor.blue, {
+    new FunctionFragment('\\frac{1}{1+e^{-x}}', PrimeColor.blue, {
       isDashed: false,
       shape: 'circle',
       legendText: 'f(x)=\\frac{1}{1+e^{-x}}'
     }),
-    new FunctionFragment('0*' + scaleY, PrimeColor.darkGreen, {
+    new FunctionFragment('0', PrimeColor.darkGreen, {
       isDashed: true,
       shape: 'triangle',
       legendText: 'y=0'
     }),
-    new FunctionFragment('1*' + scaleY, PrimeColor.raspberry, {
+    new FunctionFragment('1', PrimeColor.raspberry, {
       isDashed: true,
       shape: 'triangle',
       legendText: 'y=1'
@@ -82,10 +82,8 @@
   {cameraZoom}
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
-  axis={{
-    scaleX,
-    scaleY
-  }}
+  {scaleX}
+  {scaleY}
   legendFormulaPosition="top-left"
 >
   <TemplateComponent objects={appletObjects} />

--- a/src/routes/applet/calculus/limits_at_infinity/sine_of_x_over_x_squared/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_infinity/sine_of_x_over_x_squared/+page.svelte
@@ -58,15 +58,11 @@
   // APPLET OBJECTS
   // ##############
   const appletObjects: AppletObject[] = [
-    new FunctionFragment(
-      '\\frac{\\sin(x)}{x^2}',
-      PrimeColor.blue,
-      {
-        isDashed: false,
-        shape: 'circle',
-        legendText: 'f(x)=\\frac{\\sin(x)}{x^2}'
-      }
-    ),
+    new FunctionFragment('\\frac{\\sin(x)}{x^2}', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      legendText: 'f(x)=\\frac{\\sin(x)}{x^2}'
+    }),
     new FunctionFragment('0', PrimeColor.darkGreen, {
       isDashed: true,
       shape: 'triangle',

--- a/src/routes/applet/calculus/limits_at_infinity/sine_of_x_over_x_squared/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_infinity/sine_of_x_over_x_squared/+page.svelte
@@ -59,7 +59,7 @@
   // ##############
   const appletObjects: AppletObject[] = [
     new FunctionFragment(
-      scaleY + '\\frac{\\sin(x/' + scaleX + ')}{(x/' + scaleX + ')^2}',
+      '\\frac{\\sin(x)}{x^2}',
       PrimeColor.blue,
       {
         isDashed: false,
@@ -67,7 +67,7 @@
         legendText: 'f(x)=\\frac{\\sin(x)}{x^2}'
       }
     ),
-    new FunctionFragment('0*' + scaleY, PrimeColor.darkGreen, {
+    new FunctionFragment('0', PrimeColor.darkGreen, {
       isDashed: true,
       shape: 'triangle',
       legendText: 'y=0'
@@ -77,7 +77,7 @@
       shape: 'triangle',
       legendText: 'x=0'
     }),
-    new AsymptoteFragment(0 * scaleX, 'vertical', PrimeColor.raspberry)
+    new AsymptoteFragment(0, 'vertical', PrimeColor.raspberry)
   ];
 </script>
 
@@ -87,10 +87,8 @@
   {cameraZoom}
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
-  axis={{
-    scaleX,
-    scaleY
-  }}
+  {scaleX}
+  {scaleY}
   legendFormulaPosition="top-left"
 >
   <TemplateComponent objects={appletObjects} />

--- a/src/routes/applet/calculus/limits_at_infinity/squeeze_theorem/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_infinity/squeeze_theorem/+page.svelte
@@ -58,15 +58,11 @@
   // APPLET OBJECTS
   // ##############
   const appletObjects: AppletObject[] = [
-    new FunctionFragment(
-      '\\frac{\\sin(x)}{x^2}',
-      PrimeColor.blue,
-      {
-        isDashed: false,
-        shape: 'circle',
-        legendText: 'f(x)=\\frac{\\sin(x)}{x^2}'
-      }
-    ),
+    new FunctionFragment('\\frac{\\sin(x)}{x^2}', PrimeColor.blue, {
+      isDashed: false,
+      shape: 'circle',
+      legendText: 'f(x)=\\frac{\\sin(x)}{x^2}'
+    }),
     new FunctionFragment('\\frac{1}{x^2}', PrimeColor.darkGreen, {
       isDashed: false,
       shape: 'circle',

--- a/src/routes/applet/calculus/limits_at_infinity/squeeze_theorem/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_infinity/squeeze_theorem/+page.svelte
@@ -59,7 +59,7 @@
   // ##############
   const appletObjects: AppletObject[] = [
     new FunctionFragment(
-      scaleY + '\\frac{\\sin(' + 1 / scaleX + 'x)}{(' + 1 / scaleX + 'x)^2}',
+      '\\frac{\\sin(x)}{x^2}',
       PrimeColor.blue,
       {
         isDashed: false,
@@ -67,16 +67,16 @@
         legendText: 'f(x)=\\frac{\\sin(x)}{x^2}'
       }
     ),
-    new FunctionFragment(scaleY + '\\frac{1}{(' + 1 / scaleX + 'x)^2}', PrimeColor.darkGreen, {
+    new FunctionFragment('\\frac{1}{x^2}', PrimeColor.darkGreen, {
       isDashed: false,
       shape: 'circle',
       legendText: 'f(x)=\\pm\\frac{1}{x^2}'
     }),
-    new FunctionFragment(scaleY + '\\frac{-1}{(' + 1 / scaleX + 'x)^2}', PrimeColor.darkGreen, {
+    new FunctionFragment('\\frac{-1}{x^2}', PrimeColor.darkGreen, {
       isDashed: false,
       shape: 'circle'
     }),
-    new FunctionFragment('0*' + scaleY, PrimeColor.raspberry, {
+    new FunctionFragment('0', PrimeColor.raspberry, {
       isDashed: true,
       shape: 'triangle',
       legendText: 'y=0'
@@ -90,10 +90,8 @@
   {cameraZoom}
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
-  axis={{
-    scaleX,
-    scaleY
-  }}
+  {scaleX}
+  {scaleY}
   legendFormulaPosition="top-left"
 >
   <TemplateComponent objects={appletObjects} />

--- a/src/routes/applet/calculus/limits_at_infinity/temperature_of_a_cauliflower/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_infinity/temperature_of_a_cauliflower/+page.svelte
@@ -57,13 +57,13 @@
   // APPLET OBJECTS
   // ##############
   const appletObjects: AppletObject[] = [
-    new FunctionFragment('(5+15\\cdot e^{-x})*' + sY, PrimeColor.blue, {
+    new FunctionFragment('5+15\\cdot e^{-x}', PrimeColor.blue, {
       domain: { xMin: 0 },
       isDashed: false,
       shape: 'circle',
       legendText: 'T(t)=5+15e^{-t}'
-    }).addIncludedPoints(new Vector2(0, 20 * sY)),
-    new FunctionFragment('5*' + sY, PrimeColor.darkGreen, {
+    }).addIncludedPoints(new Vector2(0, 20)),
+    new FunctionFragment('5', PrimeColor.darkGreen, {
       domain: { xMin: 0 },
       isDashed: true,
       shape: 'triangle',
@@ -78,9 +78,7 @@
   {cameraZoom}
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
-  axis={{
-    scaleY: sY
-  }}
+  scaleY={sY}
 >
   <TemplateComponent objects={appletObjects} />
 </Canvas2D>

--- a/src/routes/applet/calculus/limits_at_infinity/temperature_of_a_cauliflower/+page.svelte
+++ b/src/routes/applet/calculus/limits_at_infinity/temperature_of_a_cauliflower/+page.svelte
@@ -40,9 +40,11 @@
   let sY = 0.2; // scale for y-axis to make the graph look better
 
   initialViewBox = new ViewBox(
-    new Vector2(-1, -1 * sY), // bottom-left
-    new Vector2(15, 25 * sY), // top-right
-    0.5 // margin
+    new Vector2(-1, -1), // bottom-left
+    new Vector2(15, 25), // top-right
+    0.5, // margin
+    1, // scaleX
+    sY // scaleY
   );
 
   // ###########

--- a/src/routes/applet/calculus/template/template_applet/+page.svelte
+++ b/src/routes/applet/calculus/template/template_applet/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  /* eslint-disable @typescript-eslint/no-unused-vars */
   // For ease of creating the template applets
   import {
     Angle,

--- a/src/routes/applet/calculus/template/template_applet/+page.svelte
+++ b/src/routes/applet/calculus/template/template_applet/+page.svelte
@@ -65,8 +65,6 @@
     showAxisNumbersY: true,
     logarithmicX: false,
     logarithmicY: false,
-    scaleX: 1,
-    scaleY: 1,
     skipX: 0,
     skipY: 0
   };

--- a/src/routes/applet/calculus/template/template_applet/+page.svelte
+++ b/src/routes/applet/calculus/template/template_applet/+page.svelte
@@ -69,6 +69,15 @@
     skipY: 0
   };
 
+  // #####
+  // SCALE
+  // #####
+  // All child components (functions, points, lines, etc.) will auto-scale accordingly.
+  // Example: scaleX={2} means 1 unit in world space = 2 display units on the x-axis.
+  // Formulas and positions should be written in display (mathematical) space.
+  let scaleX = 1;
+  let scaleY = 1;
+
   // ###########
   // AXIS LABELS
   // ###########
@@ -154,6 +163,8 @@
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
   {axis}
+  {scaleX}
+  {scaleY}
 >
   <TemplateComponent objects={appletObjects} />
 </Canvas2D>

--- a/src/routes/tutorial2d/Tutorial2D.mdx
+++ b/src/routes/tutorial2d/Tutorial2D.mdx
@@ -335,3 +335,20 @@ With the addition of controls and formulas, we have made the applet more interac
 Users can now manipulate the vectors using the sliders and see the results in real-time, while also having a clear
 understanding of the underlying mathematics. Each of these components can be further customized and you can read
 more about them in the 2D components documentation.
+
+## Scaling the coordinate system
+
+If your applet needs a different coordinate scale (for example, showing values from 0 to 2π on the x-axis but only using a few SVG units of space), you can pass `scaleX` and/or `scaleY` to `Canvas2D`:
+
+```html
+<Canvas2D scaleX={1.5} scaleY={3} title="Scaled applet">
+  <!-- All children auto-scale: positions, functions, points, axis labels, etc. -->
+  <Vector2D direction={new Vector2(1, 1)} length={1} color={PrimeColor.blue} />
+</Canvas2D>
+```
+
+- `scaleX` / `scaleY`: how many SVG (world-space) units correspond to 1 display unit. Default: `1`.
+- All child components read the scale from context and adjust automatically.
+- Specify positions and formulas in display (mathematical) space — the scaling is handled for you.
+
+For more details and examples, see the [Canvas2D documentation](./?path=/docs/initialize-canvas2d--docs).

--- a/src/routes/tutorial_template/TutorialTemplate.mdx
+++ b/src/routes/tutorial_template/TutorialTemplate.mdx
@@ -197,8 +197,8 @@ All child components (functions, points, lines, axis, etc.) automatically read t
 - **Domains and integral bounds** should be in display space. For example, `domain: { xMin: 0, xMax: 2 * Math.PI }` instead of `{ xMin: 0, xMax: 2 * Math.PI * scaleX }`.
 - **Point positions** (gaps, included points) should be in display space.
 - **Axis tick labels** automatically show display-space values.
-
-**Note:** `Latex2D` positions and `additionalTicksX`/`additionalTicksY` values remain in world space (SVG coordinates). If you use custom tick labels with scaling, multiply positions by scaleX/scaleY.
+- **`Latex2D` positions** are in display space. They automatically scale based on the active scale context.
+- **`additionalTicksX`/`additionalTicksY`** values should be in display space. The Axis component automatically converts them to world space internally.
 
 ## Optional: set axis labels
 

--- a/src/routes/tutorial_template/TutorialTemplate.mdx
+++ b/src/routes/tutorial_template/TutorialTemplate.mdx
@@ -56,14 +56,21 @@ This is the complete page component for the template applet (`src/routes/applet/
   axis = {
     showOrigin: true,
     showAxisNumbersX: true,
-    showAxisNumbersY: true
+    showAxisNumbersY: true,
     logarithmicX: false,
     logarithmicY: false,
-    scaleX: 1,
-    scaleY: 1,
     skipX: 0,
     skipY: 0
   };
+
+  // #####
+  // SCALE
+  // #####
+  // All child components (functions, points, lines, etc.) will auto-scale accordingly.
+  // Example: scaleX={2} means 1 unit in world space = 2 display units on the x-axis.
+  // Formulas and positions should be written in display (mathematical) space.
+  let scaleX = 1;
+  let scaleY = 1;
 
   // ###########
   // AXIS LABELS
@@ -95,6 +102,8 @@ This is the complete page component for the template applet (`src/routes/applet/
   legendItems={getLegend(appletObjects)}
   labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
   {axis}
+  {scaleX}
+  {scaleY}
 >
   <TemplateComponent objects={appletObjects} />
 </Canvas2D>
@@ -155,8 +164,6 @@ axis = {
   showAxisNumbersY: true,
   logarithmicX: false,
   logarithmicY: false,
-  scaleX: 1,
-  scaleY: 1,
   skipX: 0,
   skipY: 0
 };
@@ -168,10 +175,30 @@ What each option does:
 - `showAxisNumbers`: show or hide axis tick labels.
 - `logarithmicX`: use logarithmic scaling on x-axis.
 - `logarithmicY`: use logarithmic scaling on y-axis.
-- `scaleX`: multiply x-axis values by this factor.
-- `scaleY`: multiply y-axis values by this factor.
 - `skipX`: skip every n-th x-axis label/tick according to axis renderer settings.
 - `skipY`: skip every n-th y-axis label/tick according to axis renderer settings.
+
+## Optional: set scale
+
+To change the coordinate system scale, pass `scaleX` and/or `scaleY` to `Canvas2D`:
+
+```html
+<Canvas2D scaleX={1.5} scaleY={3} {axis}>
+  <TemplateComponent objects={appletObjects} />
+</Canvas2D>
+```
+
+- `scaleX`: how many SVG (world-space) units correspond to 1 display unit on the x-axis. Default: `1`.
+- `scaleY`: how many SVG (world-space) units correspond to 1 display unit on the y-axis. Default: `1`.
+
+All child components (functions, points, lines, axis, etc.) automatically read the scale from context and adjust accordingly. This means:
+
+- **Formulas** should be written in pure mathematical (display) space. For example, use `'\\cos(x)'` instead of manually pre-scaling like `'3\\cos(x/1.5)'`.
+- **Domains and integral bounds** should be in display space. For example, `domain: { xMin: 0, xMax: 2 * Math.PI }` instead of `{ xMin: 0, xMax: 2 * Math.PI * scaleX }`.
+- **Point positions** (gaps, included points) should be in display space.
+- **Axis tick labels** automatically show display-space values.
+
+**Note:** `Latex2D` positions and `additionalTicksX`/`additionalTicksY` values remain in world space (SVG coordinates). If you use custom tick labels with scaling, multiply positions by scaleX/scaleY.
 
 ## Optional: set axis labels
 


### PR DESCRIPTION
Resolves #428 

## Summary
Scale (scaleX, scaleY) is now a Canvas2D level concern rather than an Axis only prop. All d3 child components automatically read the scale from context and adjust their rendering, meaning applet authors can write formulas and positions in pure mathematical (display) space.

## Changes

### Core architecture:

- CanvasD3.svelte sets setContext('scale2D', { x: scaleX, y: scaleY })
- Canvas2D.svelte accepts scaleX/scaleY props (default 1) and passes them to CanvasD3
- Axis.svelte - removed scaleX/scaleY from AxisProps; now reads scale from context
- All d3 components read scale from context and apply it to their coordinates
- Components updated for auto-scaling: Point2D, Line2D, Circle2D (ellipse for non-uniform scale), InfiniteLine2DPolygon2D, Triangle2D, Rect2D, Angle2D, RightAngle2D, Vector2D, Trajectory2D, ExplicitFunction2D, ParameterizedFunction2D, ImplicitFunction2D
- Composite components (Vector2D, Trajectory2D, RightAngle2D, ExplicitFunction2D, ParameterizedFunction2D, ImplicitFunction2D) call setContext('scale2D', {x:1, y:1}) to prevent double-scaling of their children rendered in local coordinate space.

### Migrated applets:

- piecewise_function_with_negative_and_positive_values - removed unused scale
- linear_function - removed scaleX={1} from Axis
- piecewise_function - simplified formulas from '1*(x/1)' to 'x'
- cosine_area - moved scale to Canvas2D, formula '\\cos(x)' instead of '3\\cos(x/1.5)'
- sine_area - same pattern
- positive_and_negative_values - same pattern with shifted cosine
- an_interval_training - removed scale from axis object, simplified formulas

## Documentation:

- TutorialTemplate.mdx - removed scale from axis config, added "Optional: set scale" section
- Tutorial2D.mdx - added "Scaling the coordinate system" section
- Canvas2D.stories.svelte - improved "Scaled axis" story description, added "Non-uniform scale" story
- Template applet - added SCALE section with usage comments

## What could be improved

- AsymptoteFragment positions - vertical/horizontal asymptote positions may need review for scale-awareness depending on implementation.
- Logarithmic + scale interaction - not tested; may need special handling if both are used simultaneously.
