### PR TITLE
Fixed Slider rounding breaking parity

### DIFF
--- a/src/lib/components/controls/Slider.svelte
+++ b/src/lib/components/controls/Slider.svelte
@@ -47,7 +47,7 @@
   let playInterval: ReturnType<typeof setInterval> | undefined = $state();
 
   function round() {
-    value = Math.round(value / slider.stepSize) * slider.stepSize;
+    value = Math.round((value - slider.min) / slider.stepSize) * slider.stepSize + slider.min;
   }
 
   function stopPlaying() {


### PR DESCRIPTION
Resolves #460 

This MR changes how round() in Slider works. It takes now into account the minimum value, in order to keep parity in order and not get any unreachable values.