### PR TITLE
Make even/odd function applets draggable

### DIFF
--- a/src/routes/applet/calculus/properties_of_functions/even_function/+page.svelte
+++ b/src/routes/applet/calculus/properties_of_functions/even_function/+page.svelte
@@ -1,18 +1,16 @@
 <script lang="ts">
   // For ease of creating the template applets
-  import {
-    AppletObject,
-    FunctionFragment,
-    LineFragment,
-    Point,
-    Text
-  } from '$lib/template/TemplateAppletObjects';
+  import { AppletObject, FunctionFragment } from '$lib/template/TemplateAppletObjects';
   import TemplateComponent from '$lib/template/TemplateComponent.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import { PrimeColor } from '$lib/utils/PrimeColors';
   import { Vector2 } from 'three';
   import type { AxisProps } from '$lib/d3/Axis.svelte';
   import { ViewBox } from '$lib/d3/ViewBox';
+  import { Draggable } from '$lib/controls/Draggables.svelte';
+  import Latex2D from '$lib/d3/Latex2D.svelte';
+  import Point2D from '$lib/d3/Point2D.svelte';
+  import Line2D from '$lib/d3/Line2D.svelte';
 
   let initialViewBox: ViewBox | undefined;
   let cameraPosition: Vector2 | undefined;
@@ -56,9 +54,7 @@
     logarithmicX: false,
     logarithmicY: false,
     skipX: -1,
-    skipY: -1,
-    additionalTicksX: [Math.sqrt(3), -Math.sqrt(3)],
-    additionalTicksY: [3]
+    skipY: -1
   };
 
   // #####
@@ -67,7 +63,7 @@
   // All child components (functions, points, lines, etc.) will auto-scale accordingly.
   // Example: scaleX={2} means 1 unit in world space = 2 display units on the x-axis.
   // Formulas and positions should be written in display (mathematical) space.
-  let scaleX = 2;
+  let scaleX = 1;
   let scaleY = 1;
 
   // ###########
@@ -81,48 +77,25 @@
   // ##############
   // APPLET OBJECTS
   // ##############
-  const appletObjects: AppletObject[] = [
-    new FunctionFragment('x^2', PrimeColor.blue),
-    new Text('a', new Vector2(Math.sqrt(3), 0), PrimeColor.raspberry, {
-      alignX: 'center',
-      alignY: 'top'
-    }),
-    new Text('-a', new Vector2(-Math.sqrt(3), 0), PrimeColor.orange, {
-      alignX: 'center',
-      alignY: 'top'
-    }),
-    new Text('(-a,f(-a))', new Vector2(-Math.sqrt(3) - 0.1, 3), PrimeColor.orange, {
-      alignX: 'right',
-      alignY: 'top'
-    }),
-    new Text('(a,f(a))', new Vector2(Math.sqrt(3) + 0.1, 3), PrimeColor.raspberry, {
-      alignX: 'left',
-      alignY: 'top'
-    }),
-    new Point(new Vector2(Math.sqrt(3), 3), PrimeColor.raspberry),
-    new Point(new Vector2(-Math.sqrt(3), 3), PrimeColor.orange),
-    new LineFragment(
-      new Vector2(Math.sqrt(3), 0),
-      new Vector2(Math.sqrt(3), 3),
-      PrimeColor.raspberry,
-      { isDashed: true }
-    ),
-    new LineFragment(new Vector2(Math.sqrt(3), 3), new Vector2(0, 3), PrimeColor.raspberry, {
-      isDashed: true
-    }),
-    new LineFragment(
-      new Vector2(-Math.sqrt(3), 3),
-      new Vector2(-Math.sqrt(3), 0),
-      PrimeColor.orange,
-      { isDashed: true }
-    ),
-    new LineFragment(new Vector2(-Math.sqrt(3), 3), new Vector2(0, 3), PrimeColor.orange, {
-      isDashed: true
-    })
+
+  let aStart = Math.sqrt(3) * 2;
+  let faStart = 3;
+
+  function SnapToFunction(point: Vector2) {
+    const x = point.x > 0 ? Math.max(point.x, 0) : Math.min(point.x, 0);
+    const y = (x / 2) ** 2;
+    return new Vector2(x, y);
+  }
+
+  const draggablePoint = [
+    new Draggable(new Vector2(aStart, faStart), PrimeColor.raspberry, undefined, SnapToFunction)
   ];
+
+  const appletObjects: AppletObject[] = [new FunctionFragment('(x/2)^2', PrimeColor.blue)];
 </script>
 
 <Canvas2D
+  draggables={draggablePoint}
   {initialViewBox}
   {cameraPosition}
   {cameraZoom}
@@ -132,4 +105,66 @@
   {scaleY}
 >
   <TemplateComponent objects={appletObjects} />
+  <Latex2D
+    latex="a"
+    position={new Vector2(draggablePoint[0].position.x, 0)}
+    color={PrimeColor.raspberry}
+    alignX="center"
+    alignY="top"
+  />
+  <Latex2D
+    latex="-a"
+    position={new Vector2(-draggablePoint[0].position.x, 0)}
+    color={PrimeColor.orange}
+    alignX="center"
+    alignY="top"
+  />
+  <Latex2D
+    latex="(-a,f(-a))"
+    position={new Vector2(
+      -draggablePoint[0].position.x + (draggablePoint[0].position.x > 0 ? -0.1 : 0.1),
+      draggablePoint[0].position.y
+    )}
+    color={PrimeColor.orange}
+    alignX={draggablePoint[0].position.x > 0 ? 'right' : 'left'}
+    alignY="top"
+  />
+  <Latex2D
+    latex="(a,f(a))"
+    position={new Vector2(
+      draggablePoint[0].position.x + (draggablePoint[0].position.x < 0 ? -0.1 : 0.1),
+      draggablePoint[0].position.y
+    )}
+    color={PrimeColor.raspberry}
+    alignX={draggablePoint[0].position.x > 0 ? 'left' : 'right'}
+    alignY="top"
+  />
+  <Point2D
+    position={new Vector2(-draggablePoint[0].position.x, draggablePoint[0].position.y)}
+    color={PrimeColor.orange}
+  />
+  <Line2D
+    start={new Vector2(-draggablePoint[0].position.x, 0)}
+    end={new Vector2(-draggablePoint[0].position.x, draggablePoint[0].position.y)}
+    color={PrimeColor.orange}
+    isDashed={true}
+  />
+  <Line2D
+    start={new Vector2(0, draggablePoint[0].position.y)}
+    end={new Vector2(-draggablePoint[0].position.x, draggablePoint[0].position.y)}
+    color={PrimeColor.orange}
+    isDashed={true}
+  />
+  <Line2D
+    start={new Vector2(draggablePoint[0].position.x, 0)}
+    end={new Vector2(draggablePoint[0].position.x, draggablePoint[0].position.y)}
+    color={PrimeColor.raspberry}
+    isDashed={true}
+  />
+  <Line2D
+    start={new Vector2(0, draggablePoint[0].position.y)}
+    end={new Vector2(draggablePoint[0].position.x, draggablePoint[0].position.y)}
+    color={PrimeColor.raspberry}
+    isDashed={true}
+  />
 </Canvas2D>

--- a/src/routes/applet/calculus/properties_of_functions/odd_function/+page.svelte
+++ b/src/routes/applet/calculus/properties_of_functions/odd_function/+page.svelte
@@ -1,18 +1,16 @@
 <script lang="ts">
   // For ease of creating the template applets
-  import {
-    AppletObject,
-    FunctionFragment,
-    LineFragment,
-    Point,
-    Text
-  } from '$lib/template/TemplateAppletObjects';
+  import { AppletObject, FunctionFragment } from '$lib/template/TemplateAppletObjects';
   import TemplateComponent from '$lib/template/TemplateComponent.svelte';
   import Canvas2D from '$lib/d3/Canvas2D.svelte';
   import { PrimeColor } from '$lib/utils/PrimeColors';
   import { Vector2 } from 'three';
   import type { AxisProps } from '$lib/d3/Axis.svelte';
   import { ViewBox } from '$lib/d3/ViewBox';
+  import { Draggable } from '$lib/controls/Draggables.svelte';
+  import Latex2D from '$lib/d3/Latex2D.svelte';
+  import Point2D from '$lib/d3/Point2D.svelte';
+  import Line2D from '$lib/d3/Line2D.svelte';
 
   let initialViewBox: ViewBox | undefined;
   let cameraPosition: Vector2 | undefined;
@@ -56,9 +54,7 @@
     logarithmicX: false,
     logarithmicY: false,
     skipX: -1,
-    skipY: -1,
-    additionalTicksX: [Math.sqrt(3), -Math.sqrt(3)],
-    additionalTicksY: [3, -3]
+    skipY: -1
   };
 
   // #####
@@ -67,7 +63,7 @@
   // All child components (functions, points, lines, etc.) will auto-scale accordingly.
   // Example: scaleX={2} means 1 unit in world space = 2 display units on the x-axis.
   // Formulas and positions should be written in display (mathematical) space.
-  let scaleX = 2;
+  let scaleX = 1;
   let scaleY = 1;
 
   // ###########
@@ -81,48 +77,25 @@
   // ##############
   // APPLET OBJECTS
   // ##############
-  const appletObjects: AppletObject[] = [
-    new FunctionFragment('|x|x', PrimeColor.blue),
-    new Text('a', new Vector2(Math.sqrt(3), 0), PrimeColor.raspberry, {
-      alignX: 'center',
-      alignY: 'top'
-    }),
-    new Text('-a', new Vector2(-Math.sqrt(3), 0), PrimeColor.orange, {
-      alignX: 'center',
-      alignY: 'bottom'
-    }),
-    new Text('(-a,f(-a))', new Vector2(-Math.sqrt(3) - 0.1, -3), PrimeColor.orange, {
-      alignX: 'right',
-      alignY: 'bottom'
-    }),
-    new Text('(a,f(a))', new Vector2(Math.sqrt(3) + 0.1, 3), PrimeColor.raspberry, {
-      alignX: 'left',
-      alignY: 'top'
-    }),
-    new Point(new Vector2(Math.sqrt(3), 3), PrimeColor.raspberry),
-    new Point(new Vector2(-Math.sqrt(3), -3), PrimeColor.orange),
-    new LineFragment(
-      new Vector2(Math.sqrt(3), 0),
-      new Vector2(Math.sqrt(3), 3),
-      PrimeColor.raspberry,
-      { isDashed: true }
-    ),
-    new LineFragment(new Vector2(Math.sqrt(3), 3), new Vector2(0, 0), PrimeColor.raspberry, {
-      isDashed: true
-    }),
-    new LineFragment(
-      new Vector2(-Math.sqrt(3), -3),
-      new Vector2(-Math.sqrt(3), 0),
-      PrimeColor.orange,
-      { isDashed: true }
-    ),
-    new LineFragment(new Vector2(-Math.sqrt(3), -3), new Vector2(0, 0), PrimeColor.orange, {
-      isDashed: true
-    })
+
+  let aStart = Math.sqrt(3) * 2;
+  let faStart = 3;
+
+  function SnapToFunction(point: Vector2) {
+    const x = point.x > 0 ? Math.max(point.x, 0) : Math.min(point.x, 0);
+    const y = (x / 2) * Math.abs(x / 2);
+    return new Vector2(x, y);
+  }
+
+  const draggablePoint = [
+    new Draggable(new Vector2(aStart, faStart), PrimeColor.raspberry, undefined, SnapToFunction)
   ];
+
+  const appletObjects: AppletObject[] = [new FunctionFragment('(x/2)*|x/2|', PrimeColor.blue)];
 </script>
 
 <Canvas2D
+  draggables={draggablePoint}
   {initialViewBox}
   {cameraPosition}
   {cameraZoom}
@@ -132,4 +105,66 @@
   {scaleY}
 >
   <TemplateComponent objects={appletObjects} />
+  <Latex2D
+    latex="a"
+    position={new Vector2(draggablePoint[0].position.x, 0)}
+    color={PrimeColor.raspberry}
+    alignX="center"
+    alignY={draggablePoint[0].position.x > 0 ? 'top' : 'bottom'}
+  />
+  <Latex2D
+    latex="-a"
+    position={new Vector2(-draggablePoint[0].position.x, 0)}
+    color={PrimeColor.orange}
+    alignX="center"
+    alignY={draggablePoint[0].position.x < 0 ? 'top' : 'bottom'}
+  />
+  <Latex2D
+    latex="(-a,f(-a))"
+    position={new Vector2(
+      -draggablePoint[0].position.x + (draggablePoint[0].position.x > 0 ? -0.1 : 0.1),
+      -draggablePoint[0].position.y
+    )}
+    color={PrimeColor.orange}
+    alignX={draggablePoint[0].position.x > 0 ? 'right' : 'left'}
+    alignY={draggablePoint[0].position.x < 0 ? 'top' : 'bottom'}
+  />
+  <Latex2D
+    latex="(a,f(a))"
+    position={new Vector2(
+      draggablePoint[0].position.x + (draggablePoint[0].position.x < 0 ? -0.1 : 0.1),
+      draggablePoint[0].position.y
+    )}
+    color={PrimeColor.raspberry}
+    alignX={draggablePoint[0].position.x > 0 ? 'left' : 'right'}
+    alignY={draggablePoint[0].position.x > 0 ? 'top' : 'bottom'}
+  />
+  <Point2D
+    position={new Vector2(-draggablePoint[0].position.x, -draggablePoint[0].position.y)}
+    color={PrimeColor.orange}
+  />
+  <Line2D
+    start={new Vector2(-draggablePoint[0].position.x, 0)}
+    end={new Vector2(-draggablePoint[0].position.x, -draggablePoint[0].position.y)}
+    color={PrimeColor.orange}
+    isDashed={true}
+  />
+  <Line2D
+    start={new Vector2(0, 0)}
+    end={new Vector2(-draggablePoint[0].position.x, -draggablePoint[0].position.y)}
+    color={PrimeColor.orange}
+    isDashed={true}
+  />
+  <Line2D
+    start={new Vector2(draggablePoint[0].position.x, 0)}
+    end={new Vector2(draggablePoint[0].position.x, draggablePoint[0].position.y)}
+    color={PrimeColor.raspberry}
+    isDashed={true}
+  />
+  <Line2D
+    start={new Vector2(0, 0)}
+    end={new Vector2(draggablePoint[0].position.x, draggablePoint[0].position.y)}
+    color={PrimeColor.raspberry}
+    isDashed={true}
+  />
 </Canvas2D>


### PR DESCRIPTION
Refactors both properties-of-functions applets to use a draggable point constrained to each function instead of hardcoded points/text/line fragments. The mirrored counterpart, dashed guides, and coordinate labels are now rendered dynamically with Latex2D/Point2D/Line2D as the point moves. It also updates the plotted formulas to match the new scaling setup and removes fixed extra axis ticks tied to the old static example.