### PR TITLE
Add CanvasGrid component and implement draggable scaling

### DIFF
--- a/src/lib/common/CanvasGrid.svelte
+++ b/src/lib/common/CanvasGrid.svelte
@@ -1,0 +1,61 @@
+<script lang="ts" module>
+  import Scene from '$lib/components/Scene.svelte';
+  import type { Controller, Controls } from '$lib/controls/Controls';
+  import type { Draggable } from '$lib/controls/Draggables.svelte';
+  import type { Formula } from '$lib/utils/Formulas';
+  import type { LegendItem } from '$lib/utils/Legend';
+  import type { Snippet } from 'svelte';
+
+  export const CANVAS_GRID_KEY = Symbol('canvas-grid');
+
+  export type CanvasGridContext = {
+    registerDraggables: (draggables: Draggable[]) => void;
+    unregisterDraggables: (draggables: Draggable[]) => void;
+  };
+
+  export type CanvasGridProps = {
+    rows: number;
+    columns: number;
+    title?: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    controls?: Controls<any, readonly Controller<number | boolean | string | any>[]>;
+    formulas?: Formula[];
+    legendItems?: LegendItem[];
+    children: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import { setContext } from 'svelte';
+
+  let {
+    rows,
+    columns,
+    title,
+    controls,
+    formulas = [],
+    legendItems = [],
+    children
+  }: CanvasGridProps = $props();
+
+  let allDraggables = $state<Draggable[]>([]);
+
+  setContext<CanvasGridContext>(CANVAS_GRID_KEY, {
+    registerDraggables(draggables: Draggable[]) {
+      allDraggables = [...allDraggables, ...draggables];
+    },
+    unregisterDraggables(draggables: Draggable[]) {
+      allDraggables = allDraggables.filter((d) => !draggables.includes(d));
+    }
+  });
+</script>
+
+<Scene {title} draggables={allDraggables} {controls} {formulas} {legendItems}>
+  {#snippet sceneChildren(width: number, height: number)}
+    <div
+      style="display: grid; grid-template-rows: repeat({rows}, 1fr); grid-template-columns: repeat({columns}, 1fr); width: {width}px; height: {height}px;"
+    >
+      {@render children()}
+    </div>
+  {/snippet}
+</Scene>

--- a/src/lib/common/GridCanvas2D.svelte
+++ b/src/lib/common/GridCanvas2D.svelte
@@ -1,0 +1,53 @@
+<script lang="ts" module>
+  import type { Canvas2DProps } from '$lib/d3/CanvasD3.svelte';
+  import type { Snippet } from 'svelte';
+
+  export type GridCanvas2DProps = Omit<Canvas2DProps, 'width' | 'height' | 'children'> & {
+    gridColumn?: string;
+    gridRow?: string;
+    children: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import CanvasD3 from '$lib/d3/CanvasD3.svelte';
+  import { getContext, onMount, onDestroy } from 'svelte';
+  import { CANVAS_GRID_KEY, type CanvasGridContext } from './CanvasGrid.svelte';
+
+  let {
+    gridColumn = 'auto',
+    gridRow = 'auto',
+    children,
+    ...canvasProps
+  }: GridCanvas2DProps = $props();
+
+  let containerWidth = $state(500);
+  let containerHeight = $state(300);
+
+  const gridContext = getContext<CanvasGridContext>(CANVAS_GRID_KEY);
+  // svelte-ignore state_referenced_locally
+  const draggables = canvasProps.draggables;
+
+  onMount(() => {
+    if (gridContext && draggables?.length) {
+      gridContext.registerDraggables(draggables);
+    }
+  });
+
+  onDestroy(() => {
+    if (gridContext && draggables?.length) {
+      gridContext.unregisterDraggables(draggables);
+    }
+  });
+</script>
+
+<div
+  style="grid-column: {gridColumn}; grid-row: {gridRow}; overflow: hidden; border-width: 2px"
+  class="border-blue-500"
+  bind:clientWidth={containerWidth}
+  bind:clientHeight={containerHeight}
+>
+  <CanvasD3 width={containerWidth} height={containerHeight} {...canvasProps}>
+    {@render children()}
+  </CanvasD3>
+</div>

--- a/src/lib/common/GridCanvas3D.svelte
+++ b/src/lib/common/GridCanvas3D.svelte
@@ -1,0 +1,38 @@
+<script lang="ts" module>
+  import type { Camera3DProps } from '$lib/threlte/Camera3D.svelte';
+  import type { Snippet } from 'svelte';
+
+  export type GridCanvas3DProps = Camera3DProps & {
+    gridColumn?: string;
+    gridRow?: string;
+    children?: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import { Canvas as CanvasThrelte } from '@threlte/core';
+  import Camera3D from '$lib/threlte/Camera3D.svelte';
+  import { NoToneMapping } from 'three';
+  import { activityState } from '$lib/stores/activity.svelte';
+
+  let {
+    gridColumn = 'auto',
+    gridRow = 'auto',
+    children,
+    ...cameraProps
+  }: GridCanvas3DProps = $props();
+
+  const renderMode = $derived(activityState.isActive ? 'on-demand' : 'manual');
+</script>
+
+<div
+  style="grid-column: {gridColumn}; grid-row: {gridRow}; overflow: hidden; border-width: 2px"
+  class="border-blue-500"
+>
+  <CanvasThrelte {renderMode} toneMapping={NoToneMapping}>
+    <Camera3D {...cameraProps} />
+    {#if children}
+      {@render children()}
+    {/if}
+  </CanvasThrelte>
+</div>

--- a/src/lib/d3/Draggable2D.svelte
+++ b/src/lib/d3/Draggable2D.svelte
@@ -4,7 +4,7 @@
   import { globalState } from '$lib/stores/globalState.svelte';
   import { INTERACTIVITY_RADIUS, POINT_SIZE } from '$lib/utils/AttributeDimensions';
   import { drag, select } from 'd3';
-  import type { Snippet } from 'svelte';
+  import { getContext, type Snippet } from 'svelte';
   import { Vector2 } from 'three';
   import Latex2D from './Latex2D.svelte';
 
@@ -12,6 +12,10 @@
     draggable: Draggable;
     children?: Snippet;
   };
+
+  const scale2D = getContext('scale2D') as { x: number; y: number } | undefined;
+  const scaleX = scale2D?.x ?? 1;
+  const scaleY = scale2D?.y ?? 1;
 
   let { draggable, children }: DraggableProps = $props();
 
@@ -29,7 +33,7 @@
   }
 
   function dragged(event: DragEvent) {
-    dragPosition = new Vector2(event.x, event.y);
+    dragPosition = new Vector2(event.x / scaleX, event.y / scaleY);
 
     const newPoint = draggable.snapFn(dragPosition);
     draggable.value = new Vector2(newPoint.x, newPoint.y);
@@ -86,16 +90,26 @@
   role="button"
   tabindex="0"
   onmousedown={() => activityState.enable()}
-  style="--x:{dragPosition.x}; --y:{dragPosition.y}"
+  style="--x:{dragPosition.x * scaleX}; --y:{dragPosition.y * scaleY}"
 />
-<circle cx={draggable.value.x} cy={draggable.value.y} r={POINT_SIZE} fill={draggable.color} />
+<circle
+  cx={draggable.value.x * scaleX}
+  cy={draggable.value.y * scaleY}
+  r={POINT_SIZE}
+  fill={draggable.color}
+/>
 
 {#if children}
   {@render children()}
 {/if}
 
 <g bind:this={g}>
-  <circle cx={draggable.value.x} cy={draggable.value.y} r={INTERACTIVITY_RADIUS} opacity="0" />
+  <circle
+    cx={draggable.value.x * scaleX}
+    cy={draggable.value.y * scaleY}
+    r={INTERACTIVITY_RADIUS}
+    opacity="0"
+  />
 </g>
 
 {#if draggable.label}

--- a/src/lib/stories/CanvasGrid.stories.svelte
+++ b/src/lib/stories/CanvasGrid.stories.svelte
@@ -1,0 +1,73 @@
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import { Vector2 } from 'three';
+
+  const { Story } = defineMeta({
+    title: 'Initialize/CanvasGrid',
+    component: CanvasGrid
+  });
+</script>
+
+<script lang="ts">
+  import { globalState } from '$lib/stores/globalState.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { onDestroy } from 'svelte';
+  import CanvasGrid from '$lib/common/CanvasGrid.svelte';
+  import GridCanvas2D from '$lib/common/GridCanvas2D.svelte';
+  import Point2D from '$lib/d3/Point2D.svelte';
+  import Circle2D from '$lib/d3/Circle2D.svelte';
+  import Line2D from '$lib/d3/Line2D.svelte';
+  import GridCanvas3D from '$lib/common/GridCanvas3D.svelte';
+  import Axis3D from '$lib/threlte/Axis3D.svelte';
+  import Vector3D from '$lib/threlte/Vector3D.svelte';
+  import { MathVector3 } from '$lib/utils/MathVector';
+  import { Controls } from '$lib/controls/Controls';
+  import { Draggable } from '$lib/controls/Draggables.svelte';
+  import { Formula } from '$lib/utils/Formulas';
+
+  onDestroy(() => {
+    globalState.title = '';
+  });
+
+  const draggablesTL = [new Draggable(new Vector2(2, 1), PrimeColor.raspberry, 'P')];
+
+  const controls = Controls.addSlider(1, 0, 3, 0.1, PrimeColor.blue);
+
+  const formulas: Formula[] = [new Formula('f(x) = x')];
+</script>
+
+<!-- CanvasGrid lets you create a grid of different scenes. It works similarly to HTML grid layout.
+
+Draggables are defined for each Canvas and collected by the main CanvasGrid. Controls, formulas and legend items are all shared by each canvas.
+
+The syntax for cell column/row property is the same as with CSS: `<start-line> / <end-line>` (or `<start-line> / span <value>`) or only `<start-line>`. Hence, cells can span multiple columns or rows, as seen with the 3D scene. 
+
+When using the CanvasGrid component use GridCanvas2D and GridCanvas3D as children.
+-->
+<Story name="Example">
+  {#snippet template()}
+    <div class="h-95 overflow-hidden rounded-lg">
+      <CanvasGrid rows={2} columns={2} {controls} {formulas}>
+        <GridCanvas2D gridColumn="1" gridRow="1" draggables={draggablesTL}>
+          <Point2D position={draggablesTL[0].position} color={PrimeColor.raspberry} />
+          <Circle2D position={new Vector2(0, 0)} radius={controls[0]} color={PrimeColor.blue} />
+        </GridCanvas2D>
+
+        <GridCanvas2D gridColumn="1" gridRow="2">
+          <Point2D position={draggablesTL[0].position} color={PrimeColor.raspberry} />
+          <Line2D start={new Vector2(-2, -2)} end={new Vector2(2, 2)} color={PrimeColor.cyan} />
+          <Point2D position={new Vector2(0, 0)} color={PrimeColor.darkGreen} />
+        </GridCanvas2D>
+
+        <GridCanvas3D gridColumn="2" gridRow="1 / span 2" cameraPosition={new MathVector3(5, 5, 5)}>
+          <Axis3D />
+          <Vector3D
+            length={3 * controls[0]}
+            color={PrimeColor.blue}
+            direction={new MathVector3(-1, 0.5, 1)}
+          />
+        </GridCanvas3D>
+      </CanvasGrid>
+    </div>
+  {/snippet}
+</Story>

--- a/src/routes/applet/other/testing/canvas_grid/+page.svelte
+++ b/src/routes/applet/other/testing/canvas_grid/+page.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import CanvasGrid from '$lib/common/CanvasGrid.svelte';
+  import GridCanvas2D from '$lib/common/GridCanvas2D.svelte';
+  import GridCanvas3D from '$lib/common/GridCanvas3D.svelte';
+  import Point2D from '$lib/d3/Point2D.svelte';
+  import Circle2D from '$lib/d3/Circle2D.svelte';
+  import Line2D from '$lib/d3/Line2D.svelte';
+  import { Vector2 } from 'three';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Draggable } from '$lib/controls/Draggables.svelte';
+  import { Controls } from '$lib/controls/Controls';
+  import { MathVector3 } from '$lib/utils/MathVector';
+  import Vector3D from '$lib/threlte/Vector3D.svelte';
+  import Axis3D from '$lib/threlte/Axis3D.svelte';
+  import { Formula } from '$lib/utils/Formulas';
+
+  const draggablesTL = [new Draggable(new Vector2(2, 1), PrimeColor.raspberry, 'P')];
+
+  const controls = Controls.addSlider(1, 0, 3, 0.1, PrimeColor.blue);
+
+  const formulas: Formula[] = [new Formula('f(x) = x')];
+</script>
+
+<!-- eslint-disable-next-line local-rules/no-hardcoded-title -->
+<CanvasGrid rows={2} columns={2} title="Canvas Grid Demo" {controls} {formulas}>
+  <GridCanvas2D gridColumn="1" gridRow="1" draggables={draggablesTL}>
+    <Point2D position={draggablesTL[0].position} color={PrimeColor.raspberry} />
+    <Circle2D position={new Vector2(0, 0)} radius={controls[0]} color={PrimeColor.blue} />
+  </GridCanvas2D>
+
+  <GridCanvas2D gridColumn="1" gridRow="2">
+    <Point2D position={draggablesTL[0].position} color={PrimeColor.raspberry} />
+    <Line2D start={new Vector2(-2, -2)} end={new Vector2(2, 2)} color={PrimeColor.cyan} />
+    <Point2D position={new Vector2(0, 0)} color={PrimeColor.darkGreen} />
+  </GridCanvas2D>
+
+  <GridCanvas3D gridColumn="2" gridRow="1 / span 2" cameraPosition={new MathVector3(5, 5, 5)}>
+    <Axis3D />
+    <Vector3D
+      length={3 * controls[0]}
+      color={PrimeColor.blue}
+      direction={new MathVector3(-1, 0.5, 1)}
+    />
+  </GridCanvas3D>
+</CanvasGrid>

--- a/src/routes/applet/other/testing/canvas_scale/+page.svelte
+++ b/src/routes/applet/other/testing/canvas_scale/+page.svelte
@@ -1,0 +1,20 @@
+<script>
+  import { Draggable } from '$lib/controls/Draggables.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import Point2D from '$lib/d3/Point2D.svelte';
+  import Vector2D from '$lib/d3/Vector2D.svelte';
+  import { Vector2 } from 'three';
+
+  const draggables = [
+    new Draggable(new Vector2(1, 2), undefined, undefined, (v) => {
+      const t = (v.x + v.y) / 2;
+      return new Vector2(t, t);
+    })
+  ];
+</script>
+
+<Canvas2D scaleX={1 / 1.5} scaleY={1 / 3} {draggables}>
+  <Vector2D direction={draggables[0].position} length={draggables[0].position.length() - 0.8} />
+
+  <Point2D position={new Vector2(4, 4)} />
+</Canvas2D>


### PR DESCRIPTION
This pull request introduces a new `CanvasGrid` component system for arranging and managing multiple 2D and 3D canvas scenes in a flexible grid layout. It includes new components for grid-based 2D and 3D canvases, context-based management of draggables, and improved scaling support for draggable elements. The changes also add Storybook stories and a demo page for the new grid system.

**New Canvas Grid System**

* Added `CanvasGrid.svelte`, which provides a grid layout for arranging multiple canvases and manages draggables, controls, formulas, and legend items shared across the grid. It uses Svelte context to register and unregister draggables from child canvases.
* Introduced `GridCanvas2D.svelte` and `GridCanvas3D.svelte` components for embedding 2D and 3D scenes into grid cells, supporting grid row/column placement and automatic sizing. [[1]](diffhunk://#diff-a1f5fa62269de78e361a69dd62d4724bbf8dafbe3df8fd614ab046a56729bd8fR1-R53) [[2]](diffhunk://#diff-68679fdb83d8f53310d6a6ec3bd37f3c12b780c2d925db116f8ad246d4ffcc19R1-R38)

**Draggable Scaling and Context**

* Updated `Draggable2D.svelte` to use scaling factors from context for correct positioning and interaction of draggable elements, ensuring proper behavior when the canvas is scaled. [[1]](diffhunk://#diff-5bf5f2dbd7c7b8a5f97e4fcc776ffb72bf4169659157a9e5e90d82caa05d97a3L7-R7) [[2]](diffhunk://#diff-5bf5f2dbd7c7b8a5f97e4fcc776ffb72bf4169659157a9e5e90d82caa05d97a3R16-R19) [[3]](diffhunk://#diff-5bf5f2dbd7c7b8a5f97e4fcc776ffb72bf4169659157a9e5e90d82caa05d97a3L32-R36) [[4]](diffhunk://#diff-5bf5f2dbd7c7b8a5f97e4fcc776ffb72bf4169659157a9e5e90d82caa05d97a3L89-R112)

**Documentation and Examples**

* Added a Storybook story (`CanvasGrid.stories.svelte`) showcasing usage of the `CanvasGrid` system with both 2D and 3D scenes, controls, and draggables.
* Created a demo page at `routes/applet/other/testing/canvas_grid/+page.svelte` demonstrating the new grid layout in practice.
* Added a test page for verifying draggable scaling in `canvas_scale/+page.svelte`.