### PR TITLE
Section 4.7

### DIFF
--- a/src/routes/applet/calculus/derivatives_of_inverse_functions/failure_of_inverse_function_theorem/+page.svelte
+++ b/src/routes/applet/calculus/derivatives_of_inverse_functions/failure_of_inverse_function_theorem/+page.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+  // For ease of creating the template applets
+  import { AppletObject, FunctionFragment } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import type { AxisProps } from '$lib/d3/Axis.svelte';
+  import { Draggable } from '$lib/controls/Draggables.svelte';
+  import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';
+  import Line2D from '$lib/d3/Line2D.svelte';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+  let axis: AxisProps | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(3, 1);
+  cameraZoom = 1.5;
+
+  // (remove if unnecessary)
+  initialViewBox = new ViewBox(
+    new Vector2(-3, -3), // bottom-left
+    new Vector2(5, 5), // top-right
+    0.5 // margin
+  );
+
+  // ####
+  // AXIS
+  // ####
+  // here are the default settings for axis, you can change them
+
+  // (remove if unnecessary)
+  axis = {
+    showOrigin: true,
+    showAxisNumbersX: true,
+    showAxisNumbersY: true,
+    logarithmicX: false,
+    logarithmicY: false,
+    skipX: 0,
+    skipY: 0
+  };
+
+  // #####
+  // SCALE
+  // #####
+  // All child components (functions, points, lines, etc.) will auto-scale accordingly.
+  // Example: scaleX={2} means 1 unit in world space = 2 display units on the x-axis.
+  // Formulas and positions should be written in display (mathematical) space.
+  let scaleX = 1;
+  let scaleY = 1;
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const Function = (x: number) => (x - 1) ** 3;
+  const InverseFunction = (x: number) => Math.cbrt(x) + 1;
+  const Derivative = (x: number) => 3 * (x - 1) ** 2;
+
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment(Function, PrimeColor.blue, {
+      legendText: 'f(x)=(x-1)^3'
+    }),
+    new FunctionFragment(InverseFunction, PrimeColor.darkGreen, {
+      legendText: 'f^{-1}(x)=\\sqrt[3]{x}+1'
+    }),
+    new FunctionFragment('x', PrimeColor.black, {
+      legendText: 'y=x',
+      isDashed: true
+    })
+  ];
+
+  let masterX = $state(1);
+
+  function snapToFuncA(point: Vector2): Vector2 {
+    masterX = point.x;
+    return new Vector2(point.x, Function(point.x));
+  }
+  function snapToFuncB(point: Vector2): Vector2 {
+    masterX = InverseFunction(point.x);
+    return new Vector2(point.x, InverseFunction(point.x));
+  }
+
+  const draggablePoints = [
+    new Draggable(
+      new Vector2(1, Function(1)),
+      PrimeColor.raspberry,
+      undefined,
+      snapToFuncA,
+      undefined,
+      undefined
+      // 0.15
+    ),
+    new Draggable(
+      new Vector2(Function(1), 1),
+      PrimeColor.orange,
+      undefined,
+      snapToFuncB,
+      undefined,
+      undefined
+      // 0.15
+    )
+  ];
+
+  $effect(() => {
+    const x = masterX;
+    draggablePoints[0].value = new Vector2(x, Function(x));
+    draggablePoints[1].value = new Vector2(Function(x), x);
+  });
+</script>
+
+<Canvas2D
+  draggables={draggablePoints}
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={getLegend(appletObjects)}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+  {axis}
+  {scaleX}
+  {scaleY}
+  legendFormulaPosition="top-left"
+>
+  <TemplateComponent objects={appletObjects} />
+  <Line2D
+    start={draggablePoints[0].position}
+    end={draggablePoints[1].position}
+    color={PrimeColor.black}
+    isDashed={true}
+  />
+  <InfiniteLine2D
+    origin={draggablePoints[0].position}
+    direction={new Vector2(1, Derivative(draggablePoints[0].position.x))}
+    color={PrimeColor.raspberry}
+  />
+  <InfiniteLine2D
+    origin={draggablePoints[1].position}
+    direction={new Vector2(Derivative(draggablePoints[0].position.x), 1)}
+    color={PrimeColor.orange}
+  />
+</Canvas2D>

--- a/src/routes/applet/calculus/derivatives_of_inverse_functions/failure_of_inverse_function_theorem_2/+page.svelte
+++ b/src/routes/applet/calculus/derivatives_of_inverse_functions/failure_of_inverse_function_theorem_2/+page.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  // For ease of creating the template applets
+  import { AppletObject, FunctionFragment } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import type { AxisProps } from '$lib/d3/Axis.svelte';
+  import CanvasGrid from '$lib/common/CanvasGrid.svelte';
+  import GridCanvas2D from '$lib/common/GridCanvas2D.svelte';
+
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+  let axis: AxisProps | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(0, 0);
+  cameraZoom = 0.75;
+
+  // ####
+  // AXIS
+  // ####
+  // here are the default settings for axis, you can change them
+
+  // (remove if unnecessary)
+  axis = {
+    showOrigin: true,
+    showAxisNumbersX: true,
+    showAxisNumbersY: true,
+    logarithmicX: false,
+    logarithmicY: false,
+    skipX: 0,
+    skipY: 0
+  };
+
+  // #####
+  // SCALE
+  // #####
+  // All child components (functions, points, lines, etc.) will auto-scale accordingly.
+  // Example: scaleX={2} means 1 unit in world space = 2 display units on the x-axis.
+  // Formulas and positions should be written in display (mathematical) space.
+  let scaleX = 10;
+  let scaleY = 2;
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment((x: number) => -x + 4 * (x ** 2 * Math.sin(1 / x)), PrimeColor.blue, {
+      legendText: 'f(x)'
+    })
+  ];
+  const appletObjects2: AppletObject[] = [
+    new FunctionFragment(
+      (x: number) => -1 + 8 * x * Math.sin(1 / x) - 4 * Math.cos(1 / x),
+      PrimeColor.darkGreen,
+      { legendText: "f'(x)" }
+    )
+  ];
+</script>
+
+<CanvasGrid
+  rows={1}
+  columns={2}
+  legendItems={[...getLegend(appletObjects), ...getLegend(appletObjects2)]}
+  legendFormulaPosition="top-left"
+>
+  <GridCanvas2D
+    {cameraPosition}
+    {cameraZoom}
+    labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+    {axis}
+    {scaleX}
+    {scaleY}
+  >
+    <TemplateComponent objects={appletObjects} />
+  </GridCanvas2D>
+  <GridCanvas2D
+    {cameraPosition}
+    {cameraZoom}
+    labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+    {axis}
+    {scaleX}
+    {scaleY}
+  >
+    <TemplateComponent objects={appletObjects2} />
+  </GridCanvas2D>
+</CanvasGrid>

--- a/src/routes/applet/calculus/derivatives_of_inverse_functions/inverse_function_theorem/+page.svelte
+++ b/src/routes/applet/calculus/derivatives_of_inverse_functions/inverse_function_theorem/+page.svelte
@@ -78,7 +78,6 @@
   // ##############
   const Function = (x: number) => 5 * Math.pow(31 + x ** 2, 1 / 5) - 8;
   const Derivative = (x: number) => 5 * (((1 / 5) * (2 * x)) / Math.pow(31 + x ** 2, 4 / 5));
-  const TangentLine = (x: number, a: number) => Function(a) + Derivative(a) * (x - a);
 
   function snapToFuncA(point: Vector2): Vector2 {
     const x = Math.max(0, point.x);

--- a/src/routes/applet/calculus/derivatives_of_inverse_functions/inverse_function_theorem/+page.svelte
+++ b/src/routes/applet/calculus/derivatives_of_inverse_functions/inverse_function_theorem/+page.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+  // For ease of creating the template applets
+  import { AppletObject, FunctionFragment } from '$lib/template/TemplateAppletObjects';
+  import TemplateComponent from '$lib/template/TemplateComponent.svelte';
+  import Canvas2D from '$lib/d3/Canvas2D.svelte';
+  import { PrimeColor } from '$lib/utils/PrimeColors';
+  import { Vector2 } from 'three';
+  import { ViewBox } from '$lib/d3/ViewBox';
+  import { getLegend } from '$lib/template/ObjectFormulas';
+  import type { AxisProps } from '$lib/d3/Axis.svelte';
+  import { Draggable } from '$lib/controls/Draggables.svelte';
+  import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';
+
+  let initialViewBox: ViewBox | undefined;
+  let cameraPosition: Vector2 | undefined;
+  let cameraZoom: number | undefined;
+  let xAxisLabel: string | undefined;
+  let yAxisLabel: string | undefined;
+  let axis: AxisProps | undefined;
+
+  // ########################
+  // TUTORIAL / DOCUMENTATION
+  // ########################
+  // https://docs.openla.ewi.tudelft.nl/?path=/docs/tutorials-tutorial-template--docs
+  // on this page you can find documentation for the template objects and a tutorial on using them
+
+  // ###############
+  // CAMERA SETTINGS
+  // ###############
+  // choose one or none of the options below - if both are specified, view box will be used
+
+  // (remove if unnecessary)
+  cameraPosition = new Vector2(3, 1);
+  cameraZoom = 1.5;
+
+  // (remove if unnecessary)
+  initialViewBox = new ViewBox(
+    new Vector2(-2, -1), // bottom-left
+    new Vector2(2, 5), // top-right
+    0.5 // margin
+  );
+
+  // ####
+  // AXIS
+  // ####
+  // here are the default settings for axis, you can change them
+
+  // (remove if unnecessary)
+  axis = {
+    showOrigin: true,
+    showAxisNumbersX: true,
+    showAxisNumbersY: true,
+    logarithmicX: false,
+    logarithmicY: false,
+    skipX: 0,
+    skipY: 0
+  };
+
+  // #####
+  // SCALE
+  // #####
+  // All child components (functions, points, lines, etc.) will auto-scale accordingly.
+  // Example: scaleX={2} means 1 unit in world space = 2 display units on the x-axis.
+  // Formulas and positions should be written in display (mathematical) space.
+  let scaleX = 2;
+  let scaleY = 2;
+
+  // ###########
+  // AXIS LABELS
+  // ###########
+
+  // (remove if unnecessary)
+  xAxisLabel = 'x';
+  yAxisLabel = 'y';
+
+  // ##############
+  // APPLET OBJECTS
+  // ##############
+  const Function = (x: number) => 5 * Math.pow(31 + x ** 2, 1 / 5) - 8;
+  const Derivative = (x: number) => 5 * (((1 / 5) * (2 * x)) / Math.pow(31 + x ** 2, 4 / 5));
+  const TangentLine = (x: number, a: number) => Function(a) + Derivative(a) * (x - a);
+
+  function snapToFuncA(point: Vector2): Vector2 {
+    const x = Math.max(0, point.x);
+    return new Vector2(x, Function(x));
+  }
+  function snapToFuncB(point: Vector2): Vector2 {
+    const x = Math.min(0, point.x);
+    return new Vector2(x, Function(x));
+  }
+
+  const draggablePoints = [
+    new Draggable(
+      new Vector2(1, Function(1)),
+      PrimeColor.raspberry,
+      undefined,
+      snapToFuncA,
+      undefined,
+      undefined,
+      0.15
+    ),
+    new Draggable(
+      new Vector2(-1, Function(-1)),
+      PrimeColor.orange,
+      undefined,
+      snapToFuncB,
+      undefined,
+      undefined,
+      0.15
+    )
+  ];
+
+  const appletObjects: AppletObject[] = [
+    new FunctionFragment(Function, PrimeColor.blue, {
+      legendText: 'f(x)=5\\sqrt[5]{31+x^2}-8',
+      width: 0.1
+    })
+  ];
+</script>
+
+<Canvas2D
+  draggables={draggablePoints}
+  {initialViewBox}
+  {cameraPosition}
+  {cameraZoom}
+  legendItems={[...getLegend(appletObjects)]}
+  labels={{ xLabel: xAxisLabel ?? undefined, yLabel: yAxisLabel ?? undefined }}
+  {axis}
+  {scaleX}
+  {scaleY}
+>
+  <TemplateComponent objects={appletObjects} />
+  <InfiniteLine2D
+    origin={draggablePoints[1].position}
+    direction={new Vector2(1, Derivative(draggablePoints[1].position.x))}
+    color={PrimeColor.orange}
+    width={0.1}
+  />
+  <InfiniteLine2D
+    origin={draggablePoints[0].position}
+    direction={new Vector2(1, Derivative(draggablePoints[0].position.x))}
+    color={PrimeColor.raspberry}
+    width={0.1}
+  />
+</Canvas2D>


### PR DESCRIPTION
This pull request adds three new interactive Svelte applets for visualizing concepts related to the derivatives of inverse functions in calculus. Each applet demonstrates a different aspect, including the inverse function theorem and cases where the theorem fails. The main changes are as follows:

### New interactive applets for calculus:

* Added `failure_of_inverse_function_theorem/+page.svelte` to illustrate the failure of the inverse function theorem with interactive draggable points and tangent lines for a cubic function and its inverse.
* Added `failure_of_inverse_function_theorem_2/+page.svelte` to visualize a pathological function and its derivative, using a grid layout to compare both side by side.
* Added `inverse_function_theorem/+page.svelte` to demonstrate the inverse function theorem with draggable points and tangent lines on a root-based function.

### Visualization and UI enhancements:

* Each applet uses consistent axis labeling, camera controls, and legends for clarity, leveraging reusable template components and color schemes. [[1]](diffhunk://#diff-3f487c3bc7ac4aea5253b38a1df12410bba114e7994567b19950376ba7dfbe64R1-R165) [[2]](diffhunk://#diff-4ab82a6532293f09da9fefc05e0a12776288bc1b8f1fcfb2c8fdb3dff49f31cdR1-R110) [[3]](diffhunk://#diff-931b2c3078bd2007923aa381491ef77b3c1dd44ca1039c3d28546cbaa93c2604R1-R144)
* Interactive features include draggable points constrained to function graphs and dynamically updating tangent lines to visualize derivatives. [[1]](diffhunk://#diff-3f487c3bc7ac4aea5253b38a1df12410bba114e7994567b19950376ba7dfbe64R1-R165) [[2]](diffhunk://#diff-931b2c3078bd2007923aa381491ef77b3c1dd44ca1039c3d28546cbaa93c2604R1-R144)