### PR TITLE
Add right-angle markers to calculus applets

### DIFF
--- a/src/routes/applet/calculus/continuity/continuity_of_sine_and_cosine/+page.svelte
+++ b/src/routes/applet/calculus/continuity/continuity_of_sine_and_cosine/+page.svelte
@@ -11,6 +11,7 @@
   import Latex2D from '$lib/d3/Latex2D.svelte';
   import Line2D from '$lib/d3/Line2D.svelte';
   import Point2D from '$lib/d3/Point2D.svelte';
+  import RightAngle2D from '$lib/d3/RightAngle2D.svelte';
 
   let initialViewBox: ViewBox | undefined;
   let cameraPosition: Vector2 | undefined;
@@ -120,6 +121,12 @@
   {scaleX}
   {scaleY}
 >
+  <RightAngle2D
+    vs={[new Vector2(0, 1), new Vector2(-1, 0)]}
+    origin={new Vector2(draggablePoint[1].position.x, 0)}
+    lineWidth={0.05}
+    color={PrimeColor.yellow}
+  />
   <Circle2D
     position={new Vector2(0, 0)}
     radius={draggablePoint[0].position.x}

--- a/src/routes/applet/calculus/differentiability/tan_h_greater_than_h/+page.svelte
+++ b/src/routes/applet/calculus/differentiability/tan_h_greater_than_h/+page.svelte
@@ -12,6 +12,7 @@
   import Line2D from '$lib/d3/Line2D.svelte';
   import Point2D from '$lib/d3/Point2D.svelte';
   import InfiniteLine2D from '$lib/d3/InfiniteLine2D.svelte';
+  import RightAngle2D from '$lib/d3/RightAngle2D.svelte';
 
   let initialViewBox: ViewBox | undefined;
   let cameraPosition: Vector2 | undefined;
@@ -117,6 +118,19 @@
   {@const Cx = draggablePoint[0].position.x * Math.cos(angle)}
   {@const Cy = draggablePoint[0].position.x * Math.sin(angle)}
   {@const Dy = (A ** 2 - Cx * A) / Cy}
+
+  <RightAngle2D
+    vs={[new Vector2(0, 1), new Vector2(-1, 0)]}
+    origin={new Vector2(draggablePoint[1].position.x, 0)}
+    lineWidth={0.05}
+    color={PrimeColor.orange}
+  />
+  <RightAngle2D
+    vs={[new Vector2(A - Cx, Dy - Cy), new Vector2(Cy - Dy, A - Cx)]}
+    origin={new Vector2(Cx, Cy)}
+    lineWidth={0.05}
+    color={PrimeColor.yellow}
+  />
   <Circle2D
     position={new Vector2(0, 0)}
     radius={draggablePoint[0].position.x}


### PR DESCRIPTION
Import and render `RightAngle2D` in the continuity of sine/cosine and tan(h) > h applets. This adds visual right-angle indicators at key geometric constructions to make the proofs and diagram relationships clearer.