### PR TITLE
Normalize integral bounds order

### DIFF
--- a/src/lib/d3/ExplicitFunction2D.svelte
+++ b/src/lib/d3/ExplicitFunction2D.svelte
@@ -191,8 +191,8 @@
   const integralPath = $derived.by(() => {
     if (!integral) return null;
 
-    const xLeft = integral.xLeft * sx;
-    const xRight = integral.xRight * sx;
+    const xLeft = Math.min(integral.xLeft, integral.xRight) * sx;
+    const xRight = Math.max(integral.xLeft, integral.xRight) * sx;
     const segments: Vector2[][] = [];
     let current: Vector2[] = [];
 

--- a/src/lib/d3/FillBetweenFunctions2D.svelte
+++ b/src/lib/d3/FillBetweenFunctions2D.svelte
@@ -80,8 +80,8 @@
   const fillPath = $derived.by(() => {
     if (!integral) return null;
 
-    const xLeft = integral.xLeft * sx;
-    const xRight = integral.xRight * sx;
+    const xLeft = Math.min(integral.xLeft, integral.xRight) * sx;
+    const xRight = Math.max(integral.xLeft, integral.xRight) * sx;
 
     if (xLeft >= xRight) return null;
 


### PR DESCRIPTION
Use Math.min/max to ensure xLeft ≤ xRight regardless of input order, preventing inverted or empty integral regions when bounds are provided in reverse.